### PR TITLE
V1 Agent NodeAttestor definition

### DIFF
--- a/proto/spire/plugin/agent/nodeattestor/v1/nodeattestor.proto
+++ b/proto/spire/plugin/agent/nodeattestor/v1/nodeattestor.proto
@@ -1,37 +1,50 @@
-/** Responsible for attesting the physical nodes identity.  The plugin
-will be responsible to retrieve an identity document or data associated
-with the physical node.  This data will be used when attesting to the server.
-*/
-
 syntax = "proto3";
-package spire.agent.nodeattestor;
-option go_package = "github.com/spiffe/spire/proto/spire/agent/nodeattestor";
+package spire.plugin.agent.nodeattestor.v1;
+option go_package = "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/agent/nodeattestor/v1;nodeattestorv1";
 
-import "spire/common/common.proto";
-import "spire/common/plugin/plugin.proto";
+service NodeAttestor {
+    // FetchAttestationData retrieves the attestation payload and optionally
+    // participates in challenge/response attestation mechanics.
+    //
+    // The attestation flow is as follows:
+    // 1. SPIRE agent opens up a stream to the plugin via FetchAttestationData.
+    // 2. The plugin returns a response with the payload.
+    // 3. SPIRE agent sends the payload to SPIRE server.
+    // 4. Optionally, SPIRE server responds with a challenge:
+    //   4a. SPIRE agent sends the challenge to the plugin.
+    //   4b. The plugin responds with the challenge response.
+    //   4c. SPIRE agent sends the challenge response to SPIRE server.
+    //   4d. Step 4 is repeated until SPIRE server is satisfied and does not
+    //       respond with an additional challenge.
+    // 5. SPIRE agent closes the stream.
+    //
+    // Note that SPIRE agent does NOT send a request down the stream unless it
+    // needs to issue the challenge returned by SPIRE server (step 4a).
+    //
+    // Plugins that do not need challenge/response as part of the attestation
+    // process may close the stream as soon as they send the attestation
+    // payload (step 2).
+    rpc FetchAttestationData(stream FetchAttestationDataRequest) returns (stream FetchAttestationDataResponse);
+}
 
-/** Represents an empty request */
 message FetchAttestationDataRequest {
+    // Required. The challenge issued by the server. See the
+    // FetchAttestationData RPC for details.
     bytes challenge = 1;
 }
 
-/** Represents the attested data and base SPIFFE ID */
 message FetchAttestationDataResponse {
-    reserved 2;
+    oneof result {
+        // Required in the first response. This is the attestation payload that
+        // is to be sent to the server. See the FetchAttestationData RPC for
+        // details.
+        bytes payload = 1;
 
-    /** A type which contains attestation data for specific platform */
-    spire.common.AttestationData attestation_data = 1;
-
-    /** response to the challenge (if challenge was present) **/
-    bytes response = 3;
+        // Required in subsequent responses. The challenge response to a
+        // challenge issued by the server. See the FetchAttestationData RPC
+        // for details.
+        bytes challenge_response = 2;
+    }
 }
 
-service NodeAttestor {
-    /** Returns the node attestation data for specific platform and the generated Base SPIFFE ID for CSR formation */
-    rpc FetchAttestationData(stream FetchAttestationDataRequest) returns (stream FetchAttestationDataResponse);
 
-    /** Applies the plugin configuration and returns configuration errors */
-    rpc Configure(spire.common.plugin.ConfigureRequest) returns (spire.common.plugin.ConfigureResponse);
-    /** Returns the version and related metadata of the plugin */
-    rpc GetPluginInfo(spire.common.plugin.GetPluginInfoRequest) returns (spire.common.plugin.GetPluginInfoResponse);
-}

--- a/proto/spire/plugin/agent/nodeattestor/v1/nodeattestor.proto
+++ b/proto/spire/plugin/agent/nodeattestor/v1/nodeattestor.proto
@@ -3,8 +3,8 @@ package spire.plugin.agent.nodeattestor.v1;
 option go_package = "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/agent/nodeattestor/v1;nodeattestorv1";
 
 service NodeAttestor {
-    // FetchAttestationData retrieves the attestation payload and optionally
-    // participates in challenge/response attestation mechanics.
+    // AidAttestation facilitates attestation by returning the attestation
+    // payload and participating in attestation challenge/response.
     //
     // The attestation flow is as follows:
     // 1. SPIRE Agent opens up a stream to the plugin via FetchAttestationData.
@@ -24,27 +24,25 @@ service NodeAttestor {
     // Plugins that do not need challenge/response as part of the attestation
     // process may close the stream as soon as they send the attestation
     // payload (step 2).
-    rpc FetchAttestationData(stream FetchAttestationDataRequest) returns (stream FetchAttestationDataResponse);
+    rpc AidAttestation(stream Challenge) returns (stream PayloadOrChallengeResponse);
 }
 
-message FetchAttestationDataRequest {
-    // Required. The challenge issued by the server. See the
-    // FetchAttestationData RPC for details.
+message Challenge {
+    // Required. The challenge issued by SPIRE Server. See the AidAttestation
+    // RPC for details.
     bytes challenge = 1;
 }
 
-message FetchAttestationDataResponse {
-    oneof result {
+message PayloadOrChallengeResponse {
+    oneof data {
         // Required in the first response. This is the attestation payload that
-        // is to be sent to the server. See the FetchAttestationData RPC for
+        // is to be sent to SPIRE Server. See the AidAttestation RPC for
         // details.
         bytes payload = 1;
 
         // Required in subsequent responses. The challenge response to a
-        // challenge issued by the server. See the FetchAttestationData RPC
-        // for details.
+        // challenge issued by SPIRE Server. See the AidAttestation RPC for
+        // details.
         bytes challenge_response = 2;
     }
 }
-
-

--- a/proto/spire/plugin/agent/nodeattestor/v1/nodeattestor.proto
+++ b/proto/spire/plugin/agent/nodeattestor/v1/nodeattestor.proto
@@ -7,19 +7,19 @@ service NodeAttestor {
     // participates in challenge/response attestation mechanics.
     //
     // The attestation flow is as follows:
-    // 1. SPIRE agent opens up a stream to the plugin via FetchAttestationData.
+    // 1. SPIRE Agent opens up a stream to the plugin via FetchAttestationData.
     // 2. The plugin returns a response with the payload.
-    // 3. SPIRE agent sends the payload to SPIRE server.
-    // 4. Optionally, SPIRE server responds with a challenge:
-    //   4a. SPIRE agent sends the challenge to the plugin.
+    // 3. SPIRE Agent sends the payload to SPIRE Server.
+    // 4. Optionally, SPIRE Server responds with a challenge:
+    //   4a. SPIRE Agent sends the challenge to the plugin.
     //   4b. The plugin responds with the challenge response.
-    //   4c. SPIRE agent sends the challenge response to SPIRE server.
-    //   4d. Step 4 is repeated until SPIRE server is satisfied and does not
+    //   4c. SPIRE Agent sends the challenge response to SPIRE Server.
+    //   4d. Step 4 is repeated until SPIRE Server is satisfied and does not
     //       respond with an additional challenge.
-    // 5. SPIRE agent closes the stream.
+    // 5. SPIRE Agent closes the stream.
     //
-    // Note that SPIRE agent does NOT send a request down the stream unless it
-    // needs to issue the challenge returned by SPIRE server (step 4a).
+    // Note that SPIRE Agent does NOT send a request down the stream unless it
+    // needs to issue the challenge returned by SPIRE Server (step 4a).
     //
     // Plugins that do not need challenge/response as part of the attestation
     // process may close the stream as soon as they send the attestation


### PR DESCRIPTION
Notable changes:

- Common plugin RPCs removed
- Only the attestation data payload is returned. Type is inferred from the plugin name
- The response result uses a `oneof` to strongly communicate either the attestation data payload or the challenge response is returned, never both.