### PR TITLE
V1 Server KeyManager definition

### DIFF
--- a/proto/spire/plugin/server/keymanager/v1/keymanager.proto
+++ b/proto/spire/plugin/server/keymanager/v1/keymanager.proto
@@ -4,19 +4,20 @@ option go_package = "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/serve
 
 service KeyManager {
     // Generates a new private key with the given ID. If a key already exists
-    // under that ID, it is be overwritten. The fingerprint of the overwritten
+    // under that ID, it is overwritten. The fingerprint of the overwritten
     // key is different than the original.
     rpc GenerateKey(GenerateKeyRequest) returns (GenerateKeyResponse);
 
-    // Gets the public key information for private key managed by the plugin
-    // with the given ID.  If a key with the given ID does not exist, NOT_FOUND
-    // is returned.
+    // Gets the public key information for the private key managed by the
+    // plugin with the given ID. If a key with the given ID does not exist,
+    // NOT_FOUND is returned.
     rpc GetPublicKey(GetPublicKeyRequest) returns (GetPublicKeyResponse);
 
-    // Gets all public key information for private keys managed by the plugin.
+    // Gets all public key information for the private keys managed by the
+    // plugin.
     rpc GetPublicKeys(GetPublicKeysRequest) returns (GetPublicKeysResponse);
 
-    // Signs data with the private key with the given ID and fingerprint.  If a
+    // Signs data with the private key with the given ID and fingerprint. If a
     // key with the given ID does not exist or has a different fingerprint,
     // NOT_FOUND is returned.
     rpc SignData(SignDataRequest) returns (SignDataResponse);
@@ -87,7 +88,7 @@ message SignDataRequest {
     // Required. The fingerprint of the key to use to sign the data.
     string key_fingerprint = 2;
 
-    // Required. The data so sign.
+    // Required. The data to sign.
     bytes data = 3;
 
     // Required. The signature options. The PSS options is only valid
@@ -115,7 +116,7 @@ enum KeyType {
 enum HashAlgorithm {
     UNSPECIFIED_HASH_ALGORITHM = 0;
     // These entries (and their values) line up with a subset of the go
-    // crypto.Hash constants
+    // crypto.Hash constants.
     SHA224 = 4;
     SHA256 = 5;
     SHA384 = 6;

--- a/proto/spire/plugin/server/keymanager/v1/keymanager.proto
+++ b/proto/spire/plugin/server/keymanager/v1/keymanager.proto
@@ -4,8 +4,8 @@ option go_package = "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/serve
 
 service KeyManager {
     // Generates a new private key with the given ID. If a key already exists
-    // under that ID, it is overwritten. The fingerprint of the overwritten
-    // key is different than the original.
+    // under that ID, it is overwritten and given a different fingerprint. See
+    // the PublicKey message for more details on the role of the fingerprint.
     rpc GenerateKey(GenerateKeyRequest) returns (GenerateKeyResponse);
 
     // Gets the public key information for the private key managed by the
@@ -17,9 +17,10 @@ service KeyManager {
     // plugin.
     rpc GetPublicKeys(GetPublicKeysRequest) returns (GetPublicKeysResponse);
 
-    // Signs data with the private key with the given ID and fingerprint. If a
-    // key with the given ID does not exist or has a different fingerprint,
-    // NOT_FOUND is returned.
+    // Signs data with the private key identified by the given ID and
+    // fingerprint. If a key with the given ID does not exist or has a
+    // different fingerprint, NOT_FOUND is returned. See the PublicKey message
+    // for more details on the role of the fingerprint.
     rpc SignData(SignDataRequest) returns (SignDataResponse);
 }
 
@@ -34,10 +35,24 @@ message PublicKey {
     bytes pkix_data = 3;
 
     // Required. Fingerprint of the public key. The (id,fingerprint) tuple
-    // represents a unique identifier for the key. The fingerprint is used to
-    // ensure that a signing operation is taking place with the intended key
-    // (see SignData). Plugins are welcome to choose their fingerprinting
-    // algorithm. A naive implementation is a hash over the PKIX data.
+    // uniquely identifies an "instance" of the key. When a key is overwritten
+    // the fingerprint changes, indicating a different "instance" of that key
+    // under the given ID.
+    //
+    // Proper key rotation requires that SPIRE not overwrite a key while it is
+    // actively being used to sign data so that if the rotation operation
+    // fails, SPIRE still has a valid key to use.  The creation and use of the
+    // fingerprint to identify the key to sign data with allows SPIRE to
+    // proactively detect when it is mismanaging keys and not implementing
+    // proper key rotation semantics. This is a mitigating feature and not
+    // expected to happen under normal circumstances.
+    //
+    // There is no requirement that plugins persist the fingerprint. It can be
+    // newly generated as long as it remains consistent for a given "instance"
+    // during runtime.
+    //
+    // The fingerprinting algorithm is also left to plugin implementations. A
+    // native implementation is a non-cryptographic hash over the PKIX data.
     string fingerprint = 4;
 }
 
@@ -85,13 +100,14 @@ message SignDataRequest {
     // Required. The ID of the key to use to sign the data.
     string key_id = 1;
 
-    // Required. The fingerprint of the key to use to sign the data.
+    // Required. The fingerprint of the key to use to sign the data. See
+    // the SignData RPC for details.
     string key_fingerprint = 2;
 
     // Required. The data to sign.
     bytes data = 3;
 
-    // Required. The signature options. The PSS options is only valid
+    // Required. The signature options. The PSS options are only valid
     // for RSA keys.
     oneof signer_opts {
         HashAlgorithm hash_algorithm = 4;

--- a/proto/spire/plugin/server/keymanager/v1/keymanager.proto
+++ b/proto/spire/plugin/server/keymanager/v1/keymanager.proto
@@ -17,10 +17,11 @@ service KeyManager {
     // plugin.
     rpc GetPublicKeys(GetPublicKeysRequest) returns (GetPublicKeysResponse);
 
-    // Signs data with the private key identified by the given ID and
-    // fingerprint. If a key with the given ID does not exist or has a
-    // different fingerprint, NOT_FOUND is returned. See the PublicKey message
-    // for more details on the role of the fingerprint.
+    // Signs data with the private key identified by the given ID. If a key
+    // with the given ID does not exist, NOT_FOUND is returned. The response
+    // contains the signed data and the fingerprint of the key used to sign the
+    // data. See the PublicKey message for more details on the role of the
+    // fingerprint.
     rpc SignData(SignDataRequest) returns (SignDataResponse);
 }
 
@@ -41,15 +42,15 @@ message PublicKey {
     //
     // Proper key rotation requires that SPIRE not overwrite a key while it is
     // actively being used to sign data so that if the rotation operation
-    // fails, SPIRE still has a valid key to use.  The creation and use of the
-    // fingerprint to identify the key to sign data with allows SPIRE to
-    // proactively detect when it is mismanaging keys and not implementing
-    // proper key rotation semantics. This is a mitigating feature and not
-    // expected to happen under normal circumstances.
+    // fails, SPIRE still has a valid key to use. SPIRE compares the
+    // fingerprint returned from signing operations with the fingerprint it
+    // expected for the key as a way to detect when it has mismanaged keys.
+    // This is a mitigating measure and not expected to fail under normal
+    // circumstances.
     //
     // There is no requirement that plugins persist the fingerprint. It can be
     // newly generated as long as it remains consistent for a given "instance"
-    // during runtime.
+    // of the key during runtime.
     //
     // The fingerprinting algorithm is also left to plugin implementations. A
     // native implementation is a non-cryptographic hash over the PKIX data.
@@ -100,24 +101,23 @@ message SignDataRequest {
     // Required. The ID of the key to use to sign the data.
     string key_id = 1;
 
-    // Required. The fingerprint of the key to use to sign the data. See
-    // the SignData RPC for details.
-    string key_fingerprint = 2;
-
     // Required. The data to sign.
-    bytes data = 3;
+    bytes data = 2;
 
     // Required. The signature options. The PSS options are only valid
     // for RSA keys.
     oneof signer_opts {
-        HashAlgorithm hash_algorithm = 4;
-        PSSOptions pss_options = 5;
+        HashAlgorithm hash_algorithm = 3;
+        PSSOptions pss_options = 4;
     }
 }
 
 message SignDataResponse {
     // Required. The signature of the data.
     bytes signature = 1;
+
+    // Required. The fingerprint of the key used to sign the data.
+    string key_fingerprint = 2;
 }
 
 enum KeyType {

--- a/proto/spire/plugin/server/keymanager/v1/keymanager.proto
+++ b/proto/spire/plugin/server/keymanager/v1/keymanager.proto
@@ -1,9 +1,107 @@
 syntax = "proto3";
-package spire.server.keymanager;
-option go_package = "github.com/spiffe/spire/proto/spire/server/keymanager";
+package spire.plugin.server.keymanager.v1;
+option go_package = "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/server/keymanager/v1;keymanagerv1";
 
-import "spire/common/plugin/plugin.proto";
+service KeyManager {
+    // Generates a new private key with the given ID. If a key already exists
+    // under that ID, it is be overwritten. The fingerprint of the overwritten
+    // key is different than the original.
+    rpc GenerateKey(GenerateKeyRequest) returns (GenerateKeyResponse);
 
+    // Gets the public key information for private key managed by the plugin
+    // with the given ID.  If a key with the given ID does not exist, NOT_FOUND
+    // is returned.
+    rpc GetPublicKey(GetPublicKeyRequest) returns (GetPublicKeyResponse);
+
+    // Gets all public key information for private keys managed by the plugin.
+    rpc GetPublicKeys(GetPublicKeysRequest) returns (GetPublicKeysResponse);
+
+    // Signs data with the private key with the given ID and fingerprint.  If a
+    // key with the given ID does not exist or has a different fingerprint,
+    // NOT_FOUND is returned.
+    rpc SignData(SignDataRequest) returns (SignDataResponse);
+}
+
+message PublicKey {
+    // Required. The ID of the key, as provided when the key was created.
+    string id = 1;
+
+    // Required. The type of the key.
+    KeyType type = 2;
+
+    // Required. The public key data (PKIX encoded).
+    bytes pkix_data = 3;
+
+    // Required. Fingerprint of the public key. The (id,fingerprint) tuple
+    // represents a unique identifier for the key. The fingerprint is used to
+    // ensure that a signing operation is taking place with the intended key
+    // (see SignData). Plugins are welcome to choose their fingerprinting
+    // algorithm. A naive implementation is a hash over the PKIX data.
+    string fingerprint = 4;
+}
+
+message GenerateKeyRequest {
+    // Required. The ID to give the generated key (or to identify the existing
+    // key to overwrite (see GenerateKey).
+    string key_id = 1;
+
+    // Required. The type of the key to generate.
+    KeyType key_type = 2;
+}
+
+message GenerateKeyResponse {
+    // Required. The generated key.
+    PublicKey public_key = 1;
+}
+
+message GetPublicKeyRequest {
+    // Required. The ID of the key to retrieve.
+    string key_id = 1;
+}
+
+message GetPublicKeyResponse {
+    // Required. The public key to return.
+    PublicKey public_key = 1;
+}
+
+message GetPublicKeysRequest {
+}
+
+message GetPublicKeysResponse {
+    // Required. The public keys managed by the KeyManager. May be empty.
+    repeated PublicKey public_keys = 1;
+}
+
+message SignDataRequest {
+    message PSSOptions {
+        // Required. The salt length.
+        int32 salt_length = 1;
+
+        // Required. The hash algorithm.
+        HashAlgorithm hash_algorithm = 2;
+    }
+
+    // Required. The ID of the key to use to sign the data.
+    string key_id = 1;
+
+    // Required. The fingerprint of the key to use to sign the data.
+    string key_fingerprint = 2;
+
+    // Required. The data so sign.
+    bytes data = 3;
+
+    // Required. The signature options. The PSS options is only valid
+    // for RSA keys.
+    oneof signer_opts {
+        HashAlgorithm hash_algorithm = 4;
+        PSSOptions pss_options = 5;
+    }
+}
+
+message SignDataResponse {
+    // Required. The signature of the data.
+    bytes signature = 1;
+}
 
 enum KeyType {
     UNSPECIFIED_KEY_TYPE = 0;
@@ -28,74 +126,4 @@ enum HashAlgorithm {
     SHA3_512 = 13;
     SHA512_224 = 14;
     SHA512_256 = 15;
-}
-
-
-message PublicKey {
-    string id = 1;
-    KeyType type = 2;
-    bytes pkix_data = 3;
-}
-
-message GenerateKeyRequest {
-    string key_id = 1;
-    KeyType key_type = 2;
-}
-
-message GenerateKeyResponse {
-    PublicKey public_key = 1;
-}
-
-message GetPublicKeyRequest {
-    string key_id = 1;
-}
-
-message GetPublicKeyResponse {
-    PublicKey public_key = 1;
-}
-
-
-message GetPublicKeysRequest {
-}
-
-message GetPublicKeysResponse {
-    repeated PublicKey public_keys = 1;
-}
-
-message PSSOptions {
-    int32 salt_length = 1;
-    HashAlgorithm hash_algorithm = 2;
-}
-
-message SignDataRequest {
-    string key_id = 1;
-    bytes data = 3;
-    oneof signer_opts {
-        HashAlgorithm hash_algorithm = 2;
-        PSSOptions pss_options = 4;
-    }
-}
-
-message SignDataResponse {
-    bytes signature = 1;
-}
-
-service KeyManager {
-    // Generates a new key
-    rpc GenerateKey(GenerateKeyRequest) returns (GenerateKeyResponse);
-
-    // Get a public key by key id
-    rpc GetPublicKey(GetPublicKeyRequest) returns (GetPublicKeyResponse);
-
-    // Gets all public keys
-    rpc GetPublicKeys(GetPublicKeysRequest) returns (GetPublicKeysResponse);
-
-    // Signs data with private key
-    rpc SignData(SignDataRequest) returns (SignDataResponse);
-
-    // Applies the plugin configuration
-    rpc Configure(spire.common.plugin.ConfigureRequest) returns (spire.common.plugin.ConfigureResponse);
-
-    // Returns the version and related metadata of the installed plugin
-    rpc GetPluginInfo(spire.common.plugin.GetPluginInfoRequest) returns (spire.common.plugin.GetPluginInfoResponse);
 }


### PR DESCRIPTION
Notable Changes:

- Removed common plugin RPCs
- Moved PSSOptions into the SignRequest
- Adds the concept of a key "fingerprint". This helps detect when a caller asks for data to be signed using a key that may have been overwritten underneath the covers (by a call to GenerateKey). Right now I have it marked as required. We could also make it optional so we only provide that protection if it is provided, but I hesitate to do that. Running into this is an indication that  something is really wrong with our key management in SPIRE and I'd rather fail than do the wrong thing. For an example of what can happen: https://github.com/spiffe/spire/issues/2167