### PR TITLE
V1 Server Notifier definition

### DIFF
--- a/proto/spire/plugin/server/notifier/v1/notifier.proto
+++ b/proto/spire/plugin/server/notifier/v1/notifier.proto
@@ -1,41 +1,10 @@
 // A Notifier plugin reacts to various server related events
 
 syntax = "proto3";
-package spire.server.notifier;
-option go_package = "github.com/spiffe/spire/proto/spire/server/notifier";
+package spire.plugin.server.notifier.v1;
+option go_package = "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/server/notifier/v1;notifierv1";
 
-import "spire/common/common.proto";
-import "spire/common/plugin/plugin.proto";
-
-message BundleLoaded {
-    spire.common.Bundle bundle = 1;
-}
-
-message BundleUpdated {
-    spire.common.Bundle bundle = 1;
-}
-
-message NotifyRequest {
-    oneof event {
-        // BundleUpdated is emitted whenever SPIRE server changes the trust
-        // bundle.
-        BundleUpdated bundle_updated = 1;
-    }
-}
-
-message NotifyResponse {
-}
-
-message NotifyAndAdviseRequest {
-    oneof event {
-        // BundleLoaded is emitted on startup after SPIRE server creates/loads
-        // the trust bundle. If an error is returned SPIRE server is shut down.
-        BundleLoaded bundle_loaded = 1;
-    }
-}
-
-message NotifyAndAdviseResponse {
-}
+import "spire/plugin/types/bundle.proto";
 
 service Notifier {
     // Notify notifies the plugin that an event occurred. Errors returned by
@@ -46,7 +15,38 @@ service Notifier {
     // for a response. Errors returned by the plugin control SPIRE server
     // behavior. See NotifyAndAdviseRequest for per-event details.
     rpc NotifyAndAdvise(NotifyAndAdviseRequest) returns (NotifyAndAdviseResponse);
+}
 
-    rpc Configure(spire.common.plugin.ConfigureRequest) returns (spire.common.plugin.ConfigureResponse);
-    rpc GetPluginInfo(spire.common.plugin.GetPluginInfoRequest) returns (spire.common.plugin.GetPluginInfoResponse);
+message NotifyRequest {
+    // Required. The event the plugin is being notified for.
+    oneof event {
+        // BundleUpdated is emitted whenever SPIRE server changes the trust
+        // bundle.
+        BundleUpdated bundle_updated = 1;
+    }
+}
+
+message NotifyResponse {
+}
+
+message BundleLoaded {
+    // Required. The bundle that was loaded.
+    spire.plugin.types.Bundle bundle = 1;
+}
+
+message NotifyAndAdviseRequest {
+    // Required. The event the plugin is being notified for.
+    oneof event {
+        // BundleLoaded is emitted on startup after SPIRE server creates/loads
+        // the trust bundle. If an error is returned SPIRE server is shut down.
+        BundleLoaded bundle_loaded = 1;
+    }
+}
+
+message NotifyAndAdviseResponse {
+}
+
+message BundleUpdated {
+    // Required. The bundle that was updated.
+    spire.plugin.types.Bundle bundle = 1;
 }

--- a/proto/spire/plugin/server/notifier/v1/notifier.proto
+++ b/proto/spire/plugin/server/notifier/v1/notifier.proto
@@ -12,7 +12,7 @@ service Notifier {
     rpc Notify(NotifyRequest) returns (NotifyResponse);
 
     // NotifyAndAdvise notifies the plugin that an event occurred and waits
-    // for a response. Errors returned by the plugin control SPIRE server
+    // for a response. Errors returned by the plugin control SPIRE Server
     // behavior. See NotifyAndAdviseRequest for per-event details.
     rpc NotifyAndAdvise(NotifyAndAdviseRequest) returns (NotifyAndAdviseResponse);
 }
@@ -20,7 +20,7 @@ service Notifier {
 message NotifyRequest {
     // Required. The event the plugin is being notified for.
     oneof event {
-        // BundleUpdated is emitted whenever SPIRE server changes the trust
+        // BundleUpdated is emitted whenever SPIRE Server changes the trust
         // bundle.
         BundleUpdated bundle_updated = 1;
     }
@@ -37,8 +37,8 @@ message BundleLoaded {
 message NotifyAndAdviseRequest {
     // Required. The event the plugin is being notified for.
     oneof event {
-        // BundleLoaded is emitted on startup after SPIRE server creates/loads
-        // the trust bundle. If an error is returned SPIRE server is shut down.
+        // BundleLoaded is emitted on startup after SPIRE Server creates/loads
+        // the trust bundle. If an error is returned SPIRE Server is shut down.
         BundleLoaded bundle_loaded = 1;
     }
 }

--- a/proto/spire/plugin/types/bundle.proto
+++ b/proto/spire/plugin/types/bundle.proto
@@ -1,0 +1,24 @@
+syntax = "proto3";
+package spire.plugin.types;
+option go_package = "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/types";
+
+import "spire/plugin/types/jwtkey.proto";
+import "spire/plugin/types/x509certificate.proto";
+
+message Bundle {
+    // The name of the trust domain the bundle belongs to (e.g., "example.org").
+    string trust_domain = 1;
+
+    // X.509 authorities for authenticating X509-SVIDs.
+    repeated X509Certificate x509_authorities = 2;
+
+    // JWT authorities for authenticating JWT-SVIDs.
+    repeated JWTKey jwt_authorities = 3;
+
+    // A hint on how often the bundle should be refreshed from the bundle
+    // provider, in seconds. Can be zero (meaning no hint available).
+    int64 refresh_hint = 4;
+
+    // The sequence number of the bundle.
+    uint64 sequence_number = 5;
+}

--- a/proto/spire/plugin/types/jwtkey.proto
+++ b/proto/spire/plugin/types/jwtkey.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+package spire.plugin.types;
+option go_package = "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/types";
+
+message JWTKey {
+    // The PKIX encoded public key.
+    bytes public_key = 1;
+
+    // The key identifier.
+    string key_id = 2;
+
+    // When the key expires (seconds since Unix epoch). If zero, the key does
+    // not expire.
+    int64 expires_at = 3;
+}

--- a/proto/spire/plugin/types/x509certificate.proto
+++ b/proto/spire/plugin/types/x509certificate.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+package spire.plugin.types;
+option go_package = "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/types";
+
+message X509Certificate {
+    // The ASN.1 DER encoded bytes of the X.509 certificate.
+    bytes asn1 = 1;
+}


### PR DESCRIPTION
Notable changes:

- Common plugin RPCs removed
- The use of a _new_ bundle message in the spire/plugin/types namespace instead of the old spire/common namespace.

One thing to note: the notifier BundleLoaded and BundleUpdated messages have traditionally carried the loaded/updated bundle but so far our built-ins consistent entirely of bundle notifiers which never use these bundles. In fact, using them for bundle notifiers is a bug, since notifiers need to handle conflict resolution on updates by reloading the bundle. They do so via the identity provider.

~This plugin is also the only reason we need to have a `types` namespace at all in the plugin SDK~ (I lied... the UpstreamAuthority PublishJWTKey RPC uses the same JWTKey message). If we get rid of the bundle in these messages, we could drop the need for a types namespace at all. Alternatively, we could also just define the bundle type in the notifier proto itself. Moving it out later would be a build break, but not a wire protocol break.

Happy to hear some thoughts here.