### PR TITLE
Add Agent KeyManager template

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.14
 require (
 	github.com/hashicorp/go-hclog v0.15.0
 	github.com/hashicorp/go-plugin v1.4.0
+	github.com/hashicorp/hcl v1.0.0 // indirect
 	google.golang.org/grpc v1.36.1
 	google.golang.org/protobuf v1.26.0
 )

--- a/go.sum
+++ b/go.sum
@@ -40,6 +40,8 @@ github.com/hashicorp/go-hclog v0.15.0 h1:qMuK0wxsoW4D0ddCCYwPSTm4KQv1X1ke3WmPWZ0
 github.com/hashicorp/go-hclog v0.15.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
 github.com/hashicorp/go-plugin v1.4.0 h1:b0O7rs5uiJ99Iu9HugEzsM67afboErkHUWddUSpUO3A=
 github.com/hashicorp/go-plugin v1.4.0/go.mod h1:5fGEH17QVwTTcR0zV7yhDPLLmFX9YSZ38b18Udy6vYQ=
+github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
+github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb h1:b5rjCoWHc7eqmAS4/qyk21ZsHyb6Mxv/jykxvNTkU4M=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/jhump/protoreflect v1.6.0 h1:h5jfMVslIg6l29nsMs0D8Wj17RDVdNYti0vDN/PZZoE=

--- a/plugintest/serve.go
+++ b/plugintest/serve.go
@@ -51,6 +51,13 @@ func ServeInBackground(t *testing.T, config Config) {
 	wg := new(sync.WaitGroup)
 	t.Cleanup(wg.Wait)
 
+	switch {
+	case config.PluginServer == nil:
+		t.Fatal("PluginServer is required")
+	case config.PluginClient == nil:
+		t.Fatal("PluginClient is required")
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 	closeCh := make(chan struct{})
 

--- a/templates/agent/keymanager/keymanager.go
+++ b/templates/agent/keymanager/keymanager.go
@@ -1,0 +1,169 @@
+package keymanager
+
+import (
+	"context"
+	"sync"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/hcl"
+	"github.com/spiffe/spire-plugin-sdk/pluginmain"
+	"github.com/spiffe/spire-plugin-sdk/pluginsdk"
+	keymanagerv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/agent/keymanager/v1"
+	configv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/service/common/config/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+var (
+	// This compile time assertion ensures the plugin conforms properly to the
+	// pluginsdk.NeedsLogger interface.
+	// TODO: Remove if the plugin does not need the logger.
+	_ pluginsdk.NeedsLogger = (*Plugin)(nil)
+
+	// This compile time assertion ensures the plugin conforms properly to the
+	// pluginsdk.NeedsHostServices interface.
+	// TODO: Remove if the plugin does not need host services.
+	_ pluginsdk.NeedsHostServices = (*Plugin)(nil)
+)
+
+// Config defines the configuration for the plugin.
+// TODO: Add relevant configurables or remove if no configuration is required.
+type Config struct {
+}
+
+// Plugin implements the KeyManager plugin
+type Plugin struct {
+	// UnimplementedKeyManagerServer is embedded to satisfy gRPC
+	keymanagerv1.UnimplementedKeyManagerServer
+
+	// UnimplementedConfigServer is embedded to satisfy gRPC
+	// TODO: Remove if this plugin does not require configuration
+	configv1.UnimplementedConfigServer
+
+	// Configuration should be set atomically
+	// TODO: Remove if this plugin does not require configuration
+	configMtx sync.RWMutex
+	config    *Config
+}
+
+// SetLogger is called by the framework when the plugin is loaded and provides
+// the plugin with a logger wired up to SPIRE's logging facilities.
+// TODO: Remove if the plugin does not need the logger.
+func (p *Plugin) SetLogger(logger hclog.Logger) {
+	// TODO: Store the logger for later use
+}
+
+// BrokerHostServices is called by the framework when the plugin is loaded to
+// give the plugin a chance to obtain clients to SPIRE host services.
+// TODO: Remove if the plugin does not need host services.
+func (p *Plugin) BrokerHostServices(broker pluginsdk.ServiceBroker) error {
+	// TODO: Use the broker to obtain host service clients
+	return nil
+}
+
+// GenerateKey implements the KeyManager GenerateKey RPC
+func (p *Plugin) GenerateKey(ctx context.Context, req *keymanagerv1.GenerateKeyRequest) (*keymanagerv1.GenerateKeyResponse, error) {
+	config, err := p.getConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: Implement the RPC behavior. The following line silences compiler
+	// warnings and can be removed once the configuration is referenced by the
+	// implementation.
+	config = config
+
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+// GetPublicKey implements the KeyManager GetPublicKey RPC
+func (p *Plugin) GetPublicKey(ctx context.Context, req *keymanagerv1.GetPublicKeyRequest) (*keymanagerv1.GetPublicKeyResponse, error) {
+	config, err := p.getConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: Implement the RPC behavior. The following line silences compiler
+	// warnings and can be removed once the configuration is referenced by the
+	// implementation.
+	config = config
+
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+// GetPublicKeys implements the KeyManager GetPublicKeys RPC
+func (p *Plugin) GetPublicKeys(ctx context.Context, req *keymanagerv1.GetPublicKeysRequest) (*keymanagerv1.GetPublicKeysResponse, error) {
+	config, err := p.getConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: Implement the RPC behavior. The following line silences compiler
+	// warnings and can be removed once the configuration is referenced by the
+	// implementation.
+	config = config
+
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+// SignData implements the KeyManager SignData RPC
+func (p *Plugin) SignData(ctx context.Context, req *keymanagerv1.SignDataRequest) (*keymanagerv1.SignDataResponse, error) {
+	config, err := p.getConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: Implement the RPC behavior. The following line silences compiler
+	// warnings and can be removed once the configuration is referenced by the
+	// implementation.
+	config = config
+
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+// Configure configures the plugin. This is invoked by SPIRE when the plugin is
+// first loaded. In the future, itt may be invoked to reconfigure the plugin.
+// As such, it should replace the previous configuration atomically.
+// TODO: Remove if no configuration is required
+func (p *Plugin) Configure(ctx context.Context, req *configv1.ConfigureRequest) (*configv1.ConfigureResponse, error) {
+	config := new(Config)
+	if err := hcl.Decode(config, req.HclConfiguration); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "failed to decode configuration: %v", err)
+	}
+
+	// TODO: Validate configuration before setting/replacing existing
+	// configuration
+
+	p.setConfig(config)
+	return &configv1.ConfigureResponse{}, nil
+}
+
+// setConfig replaces the configuration atomically under a write lock.
+// TODO: Remove if no configuration is required
+func (p *Plugin) setConfig(config *Config) {
+	p.configMtx.Lock()
+	p.config = config
+	p.configMtx.Unlock()
+}
+
+// getConfig gets the configuration under a read lock.
+// TODO: Remove if no configuration is required
+func (p *Plugin) getConfig() (*Config, error) {
+	p.configMtx.RLock()
+	defer p.configMtx.RUnlock()
+	if p.config == nil {
+		return nil, status.Error(codes.FailedPrecondition, "not configured")
+	}
+	return p.config, nil
+}
+
+func main() {
+	plugin := new(Plugin)
+	// Serve the plugin. This function call will not return. If there is a
+	// failure to serve, the process will exit with a non-zero exit code.
+	pluginmain.Serve(
+		keymanagerv1.KeyManagerPluginServer(plugin),
+		// TODO: Remove if no configuration is required
+		configv1.ConfigServiceServer(plugin),
+	)
+}

--- a/templates/agent/keymanager/keymanager.go
+++ b/templates/agent/keymanager/keymanager.go
@@ -44,13 +44,17 @@ type Plugin struct {
 	// TODO: Remove if this plugin does not require configuration
 	configMtx sync.RWMutex
 	config    *Config
+
+	// The logger received from the framework via the SetLogger method
+	// TODO: Remove if this plugin does not need the logger.
+	logger hclog.Logger
 }
 
 // SetLogger is called by the framework when the plugin is loaded and provides
 // the plugin with a logger wired up to SPIRE's logging facilities.
 // TODO: Remove if the plugin does not need the logger.
 func (p *Plugin) SetLogger(logger hclog.Logger) {
-	// TODO: Store the logger for later use
+	p.logger = logger
 }
 
 // BrokerHostServices is called by the framework when the plugin is loaded to
@@ -122,7 +126,7 @@ func (p *Plugin) SignData(ctx context.Context, req *keymanagerv1.SignDataRequest
 }
 
 // Configure configures the plugin. This is invoked by SPIRE when the plugin is
-// first loaded. In the future, itt may be invoked to reconfigure the plugin.
+// first loaded. In the future, tt may be invoked to reconfigure the plugin.
 // As such, it should replace the previous configuration atomically.
 // TODO: Remove if no configuration is required
 func (p *Plugin) Configure(ctx context.Context, req *configv1.ConfigureRequest) (*configv1.ConfigureResponse, error) {

--- a/templates/agent/keymanager/keymanager_test.go
+++ b/templates/agent/keymanager/keymanager_test.go
@@ -1,0 +1,36 @@
+package keymanager_test
+
+import (
+	"testing"
+
+	"github.com/spiffe/spire-plugin-sdk/pluginsdk"
+	"github.com/spiffe/spire-plugin-sdk/plugintest"
+	keymanagerv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/agent/keymanager/v1"
+	configv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/service/common/config/v1"
+	"github.com/spiffe/spire-plugin-sdk/templates/agent/keymanager"
+)
+
+func Test(t *testing.T) {
+	plugin := new(keymanager.Plugin)
+	kmClient := new(keymanagerv1.KeyManagerPluginClient)
+	configClient := new(configv1.ConfigServiceClient)
+
+	// Serve the plugin in the background with the configured plugin and
+	// service servers. The servers will be cleaned up when the test finishes.
+	// TODO: Remove the config service server and client if no configuration
+	// is required.
+	// TODO: Provide host service server implementations if required by the
+	// plugin.
+	plugintest.ServeInBackground(t, plugintest.Config{
+		PluginServer: keymanagerv1.KeyManagerPluginServer(plugin),
+		PluginClient: kmClient,
+		ServiceServers: []pluginsdk.ServiceServer{
+			configv1.ConfigServiceServer(plugin),
+		},
+		ServiceClients: []pluginsdk.ServiceClient{
+			configClient,
+		},
+	})
+
+	// TODO: Invoke methods on the clients and assert the results
+}


### PR DESCRIPTION
This is the first of many templates that I plan on introducing to the repository to give plugin authors a jumping off point.

There is going to be a lot of repetition between the templates but I thought trying to do some sort of code sharing would confuse things.

There is no KeyManager specific guidance in here. The key manager proto definition and documentation is the canonical source of the interface behavior.

TODO's have been added at each point of consideration.