### PR TITLE
Clarify agent ID shape for NodeAttestors

### DIFF
--- a/proto/spire/plugin/server/nodeattestor/v1/nodeattestor.proto
+++ b/proto/spire/plugin/server/nodeattestor/v1/nodeattestor.proto
@@ -46,7 +46,19 @@ message AttestResponse {
 }
 
 message AgentAttributes {
-    // The ID to assign to the agent.
+    // The ID to assign to the agent. Each agent in SPIRE must have a unique ID.
+    // The convention for agent IDs is as follows:
+    //
+    // spiffe://<trust-domain>/spire/agent/<plugin-name>/<unique-suffix>
+    //
+    // with:
+    // <trust-domain>  = the trust domain that the server belongs to
+    // <plugin-name>   = the name of the plugin which attested the agent
+    // <unique-suffix> = a unique suffix for this agent
+    //
+    // As of SPIRE 1.2.1, a warning is emitted when plugins return agent IDs
+    // that do not follow the convention. Future SPIRE releases will enforce
+    // the convention (see SPIRE issue #2712).
     string spiffe_id = 1;
 
     // Optional. Selectors values to ascribe to the agent. The type of the


### PR DESCRIPTION
SPIRE has an unenforced, undocumented convention for agent IDs. SPIRE will begin warning about violations in SPIRE 1.2.1 and will enforce the convention at some future point. This PR adds some documentation to the relevant field so plugin authors are aware of the convention and the future direction.