### PR TITLE
Add missed generated code update

### DIFF
--- a/proto/spire/plugin/server/nodeattestor/v1/nodeattestor.pb.go
+++ b/proto/spire/plugin/server/nodeattestor/v1/nodeattestor.pb.go
@@ -193,7 +193,19 @@ type AgentAttributes struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// The ID to assign to the agent.
+	// The ID to assign to the agent. Each agent in SPIRE must have a unique ID.
+	// The convention for agent IDs is as follows:
+	//
+	// spiffe://<trust-domain>/spire/agent/<plugin-name>/<unique-suffix>
+	//
+	// with:
+	// <trust-domain>  = the trust domain that the server belongs to
+	// <plugin-name>   = the name of the plugin which attested the agent
+	// <unique-suffix> = a unique suffix for this agent
+	//
+	// As of SPIRE 1.2.1, a warning is emitted when plugins return agent IDs
+	// that do not follow the convention. Future SPIRE releases will enforce
+	// the convention (see SPIRE issue #2712).
 	SpiffeId string `protobuf:"bytes,1,opt,name=spiffe_id,json=spiffeId,proto3" json:"spiffe_id,omitempty"`
 	// Optional. Selectors values to ascribe to the agent. The type of the
 	// selectors will be inferred from the plugin name.


### PR DESCRIPTION
df437a2a13bac98bb26a635b323b3c8127c12e7e introduced a change to a `.proto` file, but didn't include the update to the generated Go code. This PR was generated by running `make` on `HEAD` of the `main` branch.