### PR TITLE
Fix `git-clean-check` Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,8 @@ protoc_gen_go_spire_base_dir := $(build_dir)/protoc-gen-go-spire
 protoc_gen_go_spire_dir := $(protoc_gen_go_spire_base_dir)/$(protoc_gen_go_spire_version)-go$(go_version)
 protoc_gen_go_spire_bin := $(protoc_gen_go_spire_dir)/protoc-gen-go-spire
 
+git_dirty := $(shell git --no-pager status -s)
+
 #############################################################################
 # Utility functions and targets
 #############################################################################
@@ -135,7 +137,7 @@ protoc_gen_go_spire_bin := $(protoc_gen_go_spire_dir)/protoc-gen-go-spire
 
 git-clean-check:
 ifneq ($(git_dirty),)
-	git diff
+	git --no-pager diff
 	@echo "Git repository is dirty!"
 	@false
 else


### PR DESCRIPTION
The `git_dirty` variable was not being set in the Makefile, so the`git-clean-check` was incorrectly always returning a success exit code. Set the `git_dirty` variable so that the make target works as expected.

Also set `--no-pager` in the Git commands to better handle environments where the Git configuration uses the pager for output, which requires interactive input to close the editor with the Git command output.