### PR TITLE
Add plugin templates authoring documentation

### DIFF
--- a/docs/AUTHORING.md
+++ b/docs/AUTHORING.md
@@ -3,7 +3,31 @@
 This document gives guidance for authoring plugins.
 
 SPIRE plugins implement one and only one plugin _type_ (e.g. KeyManager). They
-also implement zero or more services.
+also implement zero or more services. Below is a list of plugin types, alongside templates that can be used as a base
+for authoring plugins.
+
+
+## Templates
+
+### Agent
+
+| Plugin           | Description                                           | Template                                    |
+|------------------|-------------------------------------------------------|---------------------------------------------|
+| KeyManager       | Manages private keys and performs signing operations. | [link](../templates/agent/keymanager)       |
+| NodeAttestor     | Performs the agent side of the node attestation flow. | [link](../templates/agent/nodeattestor)     |
+| SVIDStore        | Stores workload X509-SVIDs to arbitrary destinations. | [link](../templates/agent/svidstore)        |
+| WorkloadAttestor | Attests workloads and provides selectors.             | [link](../templates/agent/workloadattestor) |
+
+### Server
+
+| Plugin            | Description                                            | Template                                      |
+|-------------------|--------------------------------------------------------|-----------------------------------------------|
+| KeyManager        | Manages private keys and performs signing operations.  | [link](../templates/server/keymanager)        |
+| NodeAttestor      | Performs the server side of the node attestation flow. | [link](../templates/server/nodeattestor)      |
+| NodeResolver      | Provides additional selectors for attested nodes.      | [link](../templates/server/noderesolver)      |
+| Notifier          | Notifies external systems of certain SPIRE events.     | [link](../templates/server/notifier)          |
+| UpstreamAuthority | Plugs SPIRE into an upstream PKI.                      | [link](../templates/server/upstreamauthority) |
+
 
 ## Configuration
 
@@ -69,7 +93,7 @@ func main() {
     plugin := new(Plugin)
     pluginmain.Serve(
         keymanagerv1.KeyManagerPluginServer(plugin),
-        configv1.ConfigPluginServer(plugin), // <-- add the Config service server implementation
+        configv1.ConfigServiceServer(plugin), // <-- add the Config service server implementation
     )
 }
 ```
@@ -150,7 +174,7 @@ plugin will fail to load.
 
 ## Cleanup
 
-Plugins are seperate processes and are terminated when the plugin is unloaded.
+Plugins are separate processes and are terminated when the plugin is unloaded.
 However, it may be desirable to perform some graceful cleanup operations.
 
 To facilitate this, if plugin/service implementations implement the io.Closer
@@ -176,7 +200,7 @@ See the package docs for more information.
 ## Running
 
 The [pluginmain](https://pkg.go.dev/github.com/spiffe/spire-plugin-sdk/pluginmain) package
-is used to run the plugin. It takes care of setting up all of the plugin facilities and
+is used to run the plugin. It takes care of setting up all the plugin facilities and
 wiring up the logger and hostservices.
 
 See the package docs for more information.

--- a/docs/AUTHORING.md
+++ b/docs/AUTHORING.md
@@ -6,8 +6,10 @@ SPIRE plugins implement one and only one plugin _type_ (e.g. KeyManager). They
 also implement zero or more services. Below is a list of plugin types, alongside templates that can be used as a base
 for authoring plugins.
 
-
 ## Templates
+Each template contains a go file that can be used as a starting point for authoring plugins. A test file is also
+provided for each template; the test file contains a test suite that can be used to verify that the plugin has been 
+loaded and is working as expected using [plugintest](https://pkg.go.dev/github.com/spiffe/spire-plugin-sdk/plugintest).
 
 ### Agent
 

--- a/docs/AUTHORING.md
+++ b/docs/AUTHORING.md
@@ -22,13 +22,14 @@ loaded and is working as expected using [plugintest](https://pkg.go.dev/github.c
 
 ### Server
 
-| Plugin            | Description                                            | Template                                      |
-|-------------------|--------------------------------------------------------|-----------------------------------------------|
-| KeyManager        | Manages private keys and performs signing operations.  | [link](../templates/server/keymanager)        |
-| NodeAttestor      | Performs the server side of the node attestation flow. | [link](../templates/server/nodeattestor)      |
-| NodeResolver      | Provides additional selectors for attested nodes.      | [link](../templates/server/noderesolver)      |
-| Notifier          | Notifies external systems of certain SPIRE events.     | [link](../templates/server/notifier)          |
-| UpstreamAuthority | Plugs SPIRE into an upstream PKI.                      | [link](../templates/server/upstreamauthority) |
+| Plugin             | Description                                            | Template                                       |
+|--------------------|--------------------------------------------------------|------------------------------------------------|
+| KeyManager         | Manages private keys and performs signing operations.  | [link](../templates/server/keymanager)         |
+| NodeAttestor       | Performs the server side of the node attestation flow. | [link](../templates/server/nodeattestor)       |
+| Notifier           | Notifies external systems of certain SPIRE events.     | [link](../templates/server/notifier)           |
+| UpstreamAuthority  | Plugs SPIRE into an upstream PKI.                      | [link](../templates/server/upstreamauthority)  |
+| CredentialComposer | Allows customization of SVID and CA attributes.        | [link](../templates/server/credentialcomposer) |
+
 
 
 ## Configuration

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -52,5 +52,5 @@ SPIRE repository can be updated by running `go get
 github.com/spiffe/spire-plugin-sdk@next` from the SPIRE repository.
 
 Relying on a pseudo versions means that this repository only needs tags
-for the offically released versions, while still allowing SPIRE to work with
+for the officially released versions, while still allowing SPIRE to work with
 unreleased changes during development.

--- a/docs/MIGRATING.md
+++ b/docs/MIGRATING.md
@@ -125,7 +125,7 @@ to couple it to that operation.
 
 The `Attest` RPC request and response fields are now contained within `oneof`'s
 to strongly convey the difference in field requirements in requests and
-responses during the atestation flow. The attestation payload no longer needs
+responses during the attestation flow. The attestation payload no longer needs
 to include a type, since that is now inferred by SPIRE from the name of the
 plugin. The selectors returned in the final response are selector values only.
 The selector type is inferred by SPIRE from the name of the plugin.

--- a/docs/NodeAttestor.md
+++ b/docs/NodeAttestor.md
@@ -1,0 +1,6 @@
+
+
+## Required Go Packages for your plugin
+- google.golang.org/grpc // for being able to return proper gRPC statuses
+- google.golang.org/grpc v1.48.0
+- github.com/hashicorp/hcl v1.0.0 // only if your plugins requires external configuration data 

--- a/docs/NodeAttestor.md
+++ b/docs/NodeAttestor.md
@@ -1,6 +1,0 @@
-
-
-## Required Go Packages for your plugin
-- google.golang.org/grpc // for being able to return proper gRPC statuses
-- google.golang.org/grpc v1.48.0
-- github.com/hashicorp/hcl v1.0.0 // only if your plugins requires external configuration data 

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/hashicorp/go-hclog v0.15.0
 	github.com/hashicorp/go-plugin v1.4.0
 	github.com/hashicorp/hcl v1.0.0
+	github.com/stretchr/testify v1.7.0
 	google.golang.org/grpc v1.48.0
 	google.golang.org/protobuf v1.28.0
 )

--- a/pluginmain/serve.go
+++ b/pluginmain/serve.go
@@ -8,13 +8,13 @@ import (
 // Serve serves the plugin using the given plugin/service servers. It does
 // not return. It is intended to be called from main(). For example:
 //
-// func main() {
-//     plugin := new(Plugin)
-//     pluginmain.Serve(
-//          keymanagerv1.KeyManagerPluginServer(plugin),
-//          configv1.ConfigPluginServer(plugin),
-//     )
-// }
+//	func main() {
+//	    plugin := new(Plugin)
+//	    pluginmain.Serve(
+//	         keymanagerv1.KeyManagerPluginServer(plugin),
+//	         configv1.ConfigServiceServer(plugin),
+//	    )
+//	}
 func Serve(pluginServer pluginsdk.PluginServer, serviceServers ...pluginsdk.ServiceServer) {
 	logger := internal.NewLogger()
 	internal.Serve(logger, logger, pluginServer, serviceServers, nil)

--- a/templates/agent/keymanager/keymanager.go
+++ b/templates/agent/keymanager/keymanager.go
@@ -15,12 +15,12 @@ import (
 )
 
 var (
-	// This compile time assertion ensures the plugin conforms properly to the
+	// This compile-time assertion ensures the plugin conforms properly to the
 	// pluginsdk.NeedsLogger interface.
 	// TODO: Remove if the plugin does not need the logger.
 	_ pluginsdk.NeedsLogger = (*Plugin)(nil)
 
-	// This compile time assertion ensures the plugin conforms properly to the
+	// This compile-time assertion ensures the plugin conforms properly to the
 	// pluginsdk.NeedsHostServices interface.
 	// TODO: Remove if the plugin does not need host services.
 	_ pluginsdk.NeedsHostServices = (*Plugin)(nil)
@@ -115,14 +115,6 @@ func (p *Plugin) SignData(ctx context.Context, req *keymanagerv1.SignDataRequest
 	return nil, status.Error(codes.Unimplemented, "not implemented")
 }
 
-// BrokerHostServices is called by the framework when the plugin is loaded to
-// give the plugin a chance to obtain clients to SPIRE host services.
-// TODO: Remove if the plugin does not need host services.
-func (p *Plugin) BrokerHostServices(broker pluginsdk.ServiceBroker) error {
-	// TODO: Use the broker to obtain host service clients
-	return nil
-}
-
 // Configure configures the plugin. This is invoked by SPIRE when the plugin is
 // first loaded. In the future, it may be invoked to reconfigure the plugin.
 // As such, it should replace the previous configuration atomically.
@@ -138,6 +130,14 @@ func (p *Plugin) Configure(ctx context.Context, req *configv1.ConfigureRequest) 
 
 	p.setConfig(config)
 	return &configv1.ConfigureResponse{}, nil
+}
+
+// BrokerHostServices is called by the framework when the plugin is loaded to
+// give the plugin a chance to obtain clients to SPIRE host services.
+// TODO: Remove if the plugin does not need host services.
+func (p *Plugin) BrokerHostServices(broker pluginsdk.ServiceBroker) error {
+	// TODO: Use the broker to obtain host service clients
+	return nil
 }
 
 // SetLogger is called by the framework when the plugin is loaded and provides

--- a/templates/agent/keymanager/keymanager.go
+++ b/templates/agent/keymanager/keymanager.go
@@ -50,22 +50,8 @@ type Plugin struct {
 	logger hclog.Logger
 }
 
-// SetLogger is called by the framework when the plugin is loaded and provides
-// the plugin with a logger wired up to SPIRE's logging facilities.
-// TODO: Remove if the plugin does not need the logger.
-func (p *Plugin) SetLogger(logger hclog.Logger) {
-	p.logger = logger
-}
-
-// BrokerHostServices is called by the framework when the plugin is loaded to
-// give the plugin a chance to obtain clients to SPIRE host services.
-// TODO: Remove if the plugin does not need host services.
-func (p *Plugin) BrokerHostServices(broker pluginsdk.ServiceBroker) error {
-	// TODO: Use the broker to obtain host service clients
-	return nil
-}
-
-// GenerateKey implements the KeyManager GenerateKey RPC
+// GenerateKey implements the KeyManager GenerateKey RPC. Generates a new private key with the given ID.
+// If a key already exists under that ID, it is overwritten and given a different fingerprint.
 func (p *Plugin) GenerateKey(ctx context.Context, req *keymanagerv1.GenerateKeyRequest) (*keymanagerv1.GenerateKeyResponse, error) {
 	config, err := p.getConfig()
 	if err != nil {
@@ -80,7 +66,8 @@ func (p *Plugin) GenerateKey(ctx context.Context, req *keymanagerv1.GenerateKeyR
 	return nil, status.Error(codes.Unimplemented, "not implemented")
 }
 
-// GetPublicKey implements the KeyManager GetPublicKey RPC
+// GetPublicKey implements the KeyManager GetPublicKey RPC. Gets the public key information for the private key managed
+// by the plugin with the given ID. If a key with the given ID does not exist, NOT_FOUND is returned.
 func (p *Plugin) GetPublicKey(ctx context.Context, req *keymanagerv1.GetPublicKeyRequest) (*keymanagerv1.GetPublicKeyResponse, error) {
 	config, err := p.getConfig()
 	if err != nil {
@@ -95,7 +82,8 @@ func (p *Plugin) GetPublicKey(ctx context.Context, req *keymanagerv1.GetPublicKe
 	return nil, status.Error(codes.Unimplemented, "not implemented")
 }
 
-// GetPublicKeys implements the KeyManager GetPublicKeys RPC
+// GetPublicKeys implements the KeyManager GetPublicKeys RPC. Gets all public key information for the private keys
+// managed by the plugin.
 func (p *Plugin) GetPublicKeys(ctx context.Context, req *keymanagerv1.GetPublicKeysRequest) (*keymanagerv1.GetPublicKeysResponse, error) {
 	config, err := p.getConfig()
 	if err != nil {
@@ -110,7 +98,9 @@ func (p *Plugin) GetPublicKeys(ctx context.Context, req *keymanagerv1.GetPublicK
 	return nil, status.Error(codes.Unimplemented, "not implemented")
 }
 
-// SignData implements the KeyManager SignData RPC
+// SignData implements the KeyManager SignData RPC. Signs data with the private key identified by the given ID. If a key
+// with the given ID does not exist, NOT_FOUND is returned. The response contains the signed data and the fingerprint of
+// the key used to sign the data. See the PublicKey message for more details on the role of the fingerprint.
 func (p *Plugin) SignData(ctx context.Context, req *keymanagerv1.SignDataRequest) (*keymanagerv1.SignDataResponse, error) {
 	config, err := p.getConfig()
 	if err != nil {
@@ -123,6 +113,21 @@ func (p *Plugin) SignData(ctx context.Context, req *keymanagerv1.SignDataRequest
 	config = config
 
 	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+// SetLogger is called by the framework when the plugin is loaded and provides
+// the plugin with a logger wired up to SPIRE's logging facilities.
+// TODO: Remove if the plugin does not need the logger.
+func (p *Plugin) SetLogger(logger hclog.Logger) {
+	p.logger = logger
+}
+
+// BrokerHostServices is called by the framework when the plugin is loaded to
+// give the plugin a chance to obtain clients to SPIRE host services.
+// TODO: Remove if the plugin does not need host services.
+func (p *Plugin) BrokerHostServices(broker pluginsdk.ServiceBroker) error {
+	// TODO: Use the broker to obtain host service clients
+	return nil
 }
 
 // Configure configures the plugin. This is invoked by SPIRE when the plugin is

--- a/templates/agent/keymanager/keymanager.go
+++ b/templates/agent/keymanager/keymanager.go
@@ -115,13 +115,6 @@ func (p *Plugin) SignData(ctx context.Context, req *keymanagerv1.SignDataRequest
 	return nil, status.Error(codes.Unimplemented, "not implemented")
 }
 
-// SetLogger is called by the framework when the plugin is loaded and provides
-// the plugin with a logger wired up to SPIRE's logging facilities.
-// TODO: Remove if the plugin does not need the logger.
-func (p *Plugin) SetLogger(logger hclog.Logger) {
-	p.logger = logger
-}
-
 // BrokerHostServices is called by the framework when the plugin is loaded to
 // give the plugin a chance to obtain clients to SPIRE host services.
 // TODO: Remove if the plugin does not need host services.
@@ -145,6 +138,13 @@ func (p *Plugin) Configure(ctx context.Context, req *configv1.ConfigureRequest) 
 
 	p.setConfig(config)
 	return &configv1.ConfigureResponse{}, nil
+}
+
+// SetLogger is called by the framework when the plugin is loaded and provides
+// the plugin with a logger wired up to SPIRE's logging facilities.
+// TODO: Remove if the plugin does not need the logger.
+func (p *Plugin) SetLogger(logger hclog.Logger) {
+	p.logger = logger
 }
 
 // setConfig replaces the configuration atomically under a write lock.

--- a/templates/agent/keymanager/keymanager.go
+++ b/templates/agent/keymanager/keymanager.go
@@ -126,7 +126,7 @@ func (p *Plugin) SignData(ctx context.Context, req *keymanagerv1.SignDataRequest
 }
 
 // Configure configures the plugin. This is invoked by SPIRE when the plugin is
-// first loaded. In the future, tt may be invoked to reconfigure the plugin.
+// first loaded. In the future, it may be invoked to reconfigure the plugin.
 // As such, it should replace the previous configuration atomically.
 // TODO: Remove if no configuration is required
 func (p *Plugin) Configure(ctx context.Context, req *configv1.ConfigureRequest) (*configv1.ConfigureResponse, error) {

--- a/templates/agent/keymanager/keymanager_test.go
+++ b/templates/agent/keymanager/keymanager_test.go
@@ -1,6 +1,7 @@
 package keymanager_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/spiffe/spire-plugin-sdk/pluginsdk"
@@ -8,6 +9,8 @@ import (
 	keymanagerv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/agent/keymanager/v1"
 	configv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/service/common/config/v1"
 	"github.com/spiffe/spire-plugin-sdk/templates/agent/keymanager"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test(t *testing.T) {
@@ -32,5 +35,24 @@ func Test(t *testing.T) {
 		},
 	})
 
-	// TODO: Invoke methods on the clients and assert the results
+	ctx := context.Background()
+
+	// TODO: Remove if no configuration is required.
+	_, err := configClient.Configure(ctx, &configv1.ConfigureRequest{
+		CoreConfiguration: &configv1.CoreConfiguration{TrustDomain: "example.org"},
+		HclConfiguration:  `{}`,
+	})
+	assert.NoError(t, err)
+
+	require.True(t, kmClient.IsInitialized())
+
+	// TODO: Make assertions using the desired plugin behavior.
+	_, err = kmClient.GenerateKey(ctx, &keymanagerv1.GenerateKeyRequest{})
+	assert.EqualError(t, err, "rpc error: code = Unimplemented desc = not implemented")
+	_, err = kmClient.GetPublicKeys(ctx, &keymanagerv1.GetPublicKeysRequest{})
+	assert.EqualError(t, err, "rpc error: code = Unimplemented desc = not implemented")
+	_, err = kmClient.GetPublicKey(ctx, &keymanagerv1.GetPublicKeyRequest{})
+	assert.EqualError(t, err, "rpc error: code = Unimplemented desc = not implemented")
+	_, err = kmClient.SignData(ctx, &keymanagerv1.SignDataRequest{})
+	assert.EqualError(t, err, "rpc error: code = Unimplemented desc = not implemented")
 }

--- a/templates/agent/keymanager/keymanager_test.go
+++ b/templates/agent/keymanager/keymanager_test.go
@@ -45,7 +45,6 @@ func Test(t *testing.T) {
 	assert.NoError(t, err)
 
 	require.True(t, kmClient.IsInitialized())
-
 	// TODO: Make assertions using the desired plugin behavior.
 	_, err = kmClient.GenerateKey(ctx, &keymanagerv1.GenerateKeyRequest{})
 	assert.EqualError(t, err, "rpc error: code = Unimplemented desc = not implemented")

--- a/templates/agent/nodeattestor/nodeattestor.go
+++ b/templates/agent/nodeattestor/nodeattestor.go
@@ -15,12 +15,12 @@ import (
 )
 
 var (
-	// This compile time assertion ensures the plugin conforms properly to the
+	// This compile-time assertion ensures the plugin conforms properly to the
 	// pluginsdk.NeedsLogger interface.
 	// TODO: Remove if the plugin does not need the logger.
 	_ pluginsdk.NeedsLogger = (*Plugin)(nil)
 
-	// This compile time assertion ensures the plugin conforms properly to the
+	// This compile-time assertion ensures the plugin conforms properly to the
 	// pluginsdk.NeedsHostServices interface.
 	// TODO: Remove if the plugin does not need host services.
 	_ pluginsdk.NeedsHostServices = (*Plugin)(nil)
@@ -67,14 +67,6 @@ func (p *Plugin) AidAttestation(stream nodeattestorv1.NodeAttestor_AidAttestatio
 	return status.Error(codes.Unimplemented, "not implemented")
 }
 
-// BrokerHostServices is called by the framework when the plugin is loaded to
-// give the plugin a chance to obtain clients to SPIRE host services.
-// TODO: Remove if the plugin does not need host services.
-func (p *Plugin) BrokerHostServices(broker pluginsdk.ServiceBroker) error {
-	// TODO: Use the broker to obtain host service clients
-	return nil
-}
-
 // Configure configures the plugin. This is invoked by SPIRE when the plugin is
 // first loaded. In the future, it may be invoked to reconfigure the plugin.
 // As such, it should replace the previous configuration atomically.
@@ -90,6 +82,14 @@ func (p *Plugin) Configure(ctx context.Context, req *configv1.ConfigureRequest) 
 
 	p.setConfig(config)
 	return &configv1.ConfigureResponse{}, nil
+}
+
+// BrokerHostServices is called by the framework when the plugin is loaded to
+// give the plugin a chance to obtain clients to SPIRE host services.
+// TODO: Remove if the plugin does not need host services.
+func (p *Plugin) BrokerHostServices(broker pluginsdk.ServiceBroker) error {
+	// TODO: Use the broker to obtain host service clients
+	return nil
 }
 
 // SetLogger is called by the framework when the plugin is loaded and provides

--- a/templates/agent/nodeattestor/nodeattestor.go
+++ b/templates/agent/nodeattestor/nodeattestor.go
@@ -51,21 +51,6 @@ type Plugin struct {
 	logger hclog.Logger
 }
 
-// SetLogger is called by the framework when the plugin is loaded and provides
-// the plugin with a logger wired up to SPIRE's logging facilities.
-// TODO: Remove if the plugin does not need the logger.
-func (p *Plugin) SetLogger(logger hclog.Logger) {
-	p.logger = logger
-}
-
-// BrokerHostServices is called by the framework when the plugin is loaded to
-// give the plugin a chance to obtain clients to SPIRE host services.
-// TODO: Remove if the plugin does not need host services.
-func (p *Plugin) BrokerHostServices(broker pluginsdk.ServiceBroker) error {
-	// TODO: Use the broker to obtain host service clients
-	return nil
-}
-
 // AidAttestation implements the NodeAttestor AidAttestation RPC. AidAttestation facilitates attestation by returning
 // the attestation payload and participating in attestation challenge/response. This RPC uses a bidirectional stream for
 // communication.
@@ -81,6 +66,21 @@ func (p *Plugin) AidAttestation(stream nodeattestorv1.NodeAttestor_AidAttestatio
 	config = config
 
 	return status.Error(codes.Unimplemented, "not implemented")
+}
+
+// SetLogger is called by the framework when the plugin is loaded and provides
+// the plugin with a logger wired up to SPIRE's logging facilities.
+// TODO: Remove if the plugin does not need the logger.
+func (p *Plugin) SetLogger(logger hclog.Logger) {
+	p.logger = logger
+}
+
+// BrokerHostServices is called by the framework when the plugin is loaded to
+// give the plugin a chance to obtain clients to SPIRE host services.
+// TODO: Remove if the plugin does not need host services.
+func (p *Plugin) BrokerHostServices(broker pluginsdk.ServiceBroker) error {
+	// TODO: Use the broker to obtain host service clients
+	return nil
 }
 
 // Configure configures the plugin. This is invoked by SPIRE when the plugin is

--- a/templates/agent/nodeattestor/nodeattestor.go
+++ b/templates/agent/nodeattestor/nodeattestor.go
@@ -29,7 +29,6 @@ var (
 // Config defines the configuration for the plugin.
 // TODO: Add relevant configurables or remove if no configuration is required.
 type Config struct {
-	//	configurable fields go here...
 }
 
 // Plugin implements the NodeAttestor plugin

--- a/templates/agent/nodeattestor/nodeattestor.go
+++ b/templates/agent/nodeattestor/nodeattestor.go
@@ -15,7 +15,7 @@ import (
 )
 
 var (
-	// This compiles time assertion ensures the plugin conforms properly to the
+	// This compile time assertion ensures the plugin conforms properly to the
 	// pluginsdk.NeedsLogger interface.
 	// TODO: Remove if the plugin does not need the logger.
 	_ pluginsdk.NeedsLogger = (*Plugin)(nil)
@@ -67,13 +67,6 @@ func (p *Plugin) AidAttestation(stream nodeattestorv1.NodeAttestor_AidAttestatio
 	return status.Error(codes.Unimplemented, "not implemented")
 }
 
-// SetLogger is called by the framework when the plugin is loaded and provides
-// the plugin with a logger wired up to SPIRE's logging facilities.
-// TODO: Remove if the plugin does not need the logger.
-func (p *Plugin) SetLogger(logger hclog.Logger) {
-	p.logger = logger
-}
-
 // BrokerHostServices is called by the framework when the plugin is loaded to
 // give the plugin a chance to obtain clients to SPIRE host services.
 // TODO: Remove if the plugin does not need host services.
@@ -97,6 +90,13 @@ func (p *Plugin) Configure(ctx context.Context, req *configv1.ConfigureRequest) 
 
 	p.setConfig(config)
 	return &configv1.ConfigureResponse{}, nil
+}
+
+// SetLogger is called by the framework when the plugin is loaded and provides
+// the plugin with a logger wired up to SPIRE's logging facilities.
+// TODO: Remove if the plugin does not need the logger.
+func (p *Plugin) SetLogger(logger hclog.Logger) {
+	p.logger = logger
 }
 
 // setConfig replaces the configuration atomically under a write lock.

--- a/templates/agent/nodeattestor/nodeattestor.go
+++ b/templates/agent/nodeattestor/nodeattestor.go
@@ -15,7 +15,7 @@ import (
 )
 
 var (
-	// This compile time assertion ensures the plugin conforms properly to the
+	// This compiles time assertion ensures the plugin conforms properly to the
 	// pluginsdk.NeedsLogger interface.
 	// TODO: Remove if the plugin does not need the logger.
 	_ pluginsdk.NeedsLogger = (*Plugin)(nil)
@@ -29,6 +29,7 @@ var (
 // Config defines the configuration for the plugin.
 // TODO: Add relevant configurables or remove if no configuration is required.
 type Config struct {
+	//	configurable fields go here...
 }
 
 // Plugin implements the NodeAttestor plugin
@@ -65,7 +66,9 @@ func (p *Plugin) BrokerHostServices(broker pluginsdk.ServiceBroker) error {
 	return nil
 }
 
-// AidAttestation implements the NodeAttestor AidAttestation RPC
+// AidAttestation implements the NodeAttestor AidAttestation RPC. AidAttestation facilitates attestation by returning
+// the attestation payload and participating in attestation challenge/response. This RPC uses a bidirectional stream for
+// communication.
 func (p *Plugin) AidAttestation(stream nodeattestorv1.NodeAttestor_AidAttestationServer) error {
 	config, err := p.getConfig()
 	if err != nil {
@@ -81,7 +84,7 @@ func (p *Plugin) AidAttestation(stream nodeattestorv1.NodeAttestor_AidAttestatio
 }
 
 // Configure configures the plugin. This is invoked by SPIRE when the plugin is
-// first loaded. In the future, tt may be invoked to reconfigure the plugin.
+// first loaded. In the future, it may be invoked to reconfigure the plugin.
 // As such, it should replace the previous configuration atomically.
 // TODO: Remove if no configuration is required
 func (p *Plugin) Configure(ctx context.Context, req *configv1.ConfigureRequest) (*configv1.ConfigureResponse, error) {

--- a/templates/agent/nodeattestor/nodeattestor_test.go
+++ b/templates/agent/nodeattestor/nodeattestor_test.go
@@ -47,7 +47,7 @@ func Test(t *testing.T) {
 	require.True(t, naClient.IsInitialized())
 
 	// TODO: Make assertions using the desired plugin behavior.
-	resp, err := naClient.AidAttestation(context.Background())
+	resp, err := naClient.AidAttestation(ctx)
 	require.NoError(t, err)
 	_, err = resp.Recv()
 	assert.EqualError(t, err, "rpc error: code = Unimplemented desc = not implemented")

--- a/templates/agent/nodeattestor/nodeattestor_test.go
+++ b/templates/agent/nodeattestor/nodeattestor_test.go
@@ -45,7 +45,6 @@ func Test(t *testing.T) {
 	assert.NoError(t, err)
 
 	require.True(t, naClient.IsInitialized())
-
 	// TODO: Make assertions using the desired plugin behavior.
 	resp, err := naClient.AidAttestation(ctx)
 	require.NoError(t, err)

--- a/templates/agent/nodeattestor/nodeattestor_test.go
+++ b/templates/agent/nodeattestor/nodeattestor_test.go
@@ -1,6 +1,7 @@
 package nodeattestor_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/spiffe/spire-plugin-sdk/pluginsdk"
@@ -8,6 +9,8 @@ import (
 	nodeattestorv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/agent/nodeattestor/v1"
 	configv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/service/common/config/v1"
 	"github.com/spiffe/spire-plugin-sdk/templates/agent/nodeattestor"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test(t *testing.T) {
@@ -32,5 +35,20 @@ func Test(t *testing.T) {
 		},
 	})
 
-	// TODO: Invoke methods on the clients and assert the results
+	ctx := context.Background()
+
+	// TODO: Remove if no configuration is required.
+	_, err := configClient.Configure(ctx, &configv1.ConfigureRequest{
+		CoreConfiguration: &configv1.CoreConfiguration{TrustDomain: "example.org"},
+		HclConfiguration:  `{}`,
+	})
+	assert.NoError(t, err)
+
+	require.True(t, naClient.IsInitialized())
+
+	// TODO: Make assertions using the desired plugin behavior.
+	resp, err := naClient.AidAttestation(context.Background())
+	require.NoError(t, err)
+	_, err = resp.Recv()
+	assert.EqualError(t, err, "rpc error: code = Unimplemented desc = not implemented")
 }

--- a/templates/agent/nodeattestor/nodeattestor_test.go
+++ b/templates/agent/nodeattestor/nodeattestor_test.go
@@ -35,7 +35,8 @@ func Test(t *testing.T) {
 		},
 	})
 
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	// TODO: Remove if no configuration is required.
 	_, err := configClient.Configure(ctx, &configv1.ConfigureRequest{
@@ -46,8 +47,8 @@ func Test(t *testing.T) {
 
 	require.True(t, naClient.IsInitialized())
 	// TODO: Make assertions using the desired plugin behavior.
-	resp, err := naClient.AidAttestation(ctx)
+	stream, err := naClient.AidAttestation(ctx)
 	require.NoError(t, err)
-	_, err = resp.Recv()
+	_, err = stream.Recv()
 	assert.EqualError(t, err, "rpc error: code = Unimplemented desc = not implemented")
 }

--- a/templates/agent/svidstore/svidstore.go
+++ b/templates/agent/svidstore/svidstore.go
@@ -65,7 +65,7 @@ func (p *Plugin) DeleteX509SVID(ctx context.Context, req *svidstorev1.DeleteX509
 	return nil, status.Error(codes.Unimplemented, "not implemented")
 }
 
-// PutX509SVID implements the SVIDStore PutX509SVID RPC. Deletes an SVID from the store
+// PutX509SVID implements the SVIDStore PutX509SVID RPC. Deletes an SVID from the store.
 func (p *Plugin) PutX509SVID(ctx context.Context, req *svidstorev1.PutX509SVIDRequest) (*svidstorev1.PutX509SVIDResponse, error) {
 	config, err := p.getConfig()
 	if err != nil {
@@ -78,13 +78,6 @@ func (p *Plugin) PutX509SVID(ctx context.Context, req *svidstorev1.PutX509SVIDRe
 	config = config
 
 	return nil, status.Error(codes.Unimplemented, "not implemented")
-}
-
-// SetLogger is called by the framework when the plugin is loaded and provides
-// the plugin with a logger wired up to SPIRE's logging facilities.
-// TODO: Remove if the plugin does not need the logger.
-func (p *Plugin) SetLogger(logger hclog.Logger) {
-	p.logger = logger
 }
 
 // BrokerHostServices is called by the framework when the plugin is loaded to
@@ -110,6 +103,13 @@ func (p *Plugin) Configure(ctx context.Context, req *configv1.ConfigureRequest) 
 
 	p.setConfig(config)
 	return &configv1.ConfigureResponse{}, nil
+}
+
+// SetLogger is called by the framework when the plugin is loaded and provides
+// the plugin with a logger wired up to SPIRE's logging facilities.
+// TODO: Remove if the plugin does not need the logger.
+func (p *Plugin) SetLogger(logger hclog.Logger) {
+	p.logger = logger
 }
 
 // setConfig replaces the configuration atomically under a write lock.

--- a/templates/agent/svidstore/svidstore.go
+++ b/templates/agent/svidstore/svidstore.go
@@ -50,22 +50,7 @@ type Plugin struct {
 	logger hclog.Logger
 }
 
-// SetLogger is called by the framework when the plugin is loaded and provides
-// the plugin with a logger wired up to SPIRE's logging facilities.
-// TODO: Remove if the plugin does not need the logger.
-func (p *Plugin) SetLogger(logger hclog.Logger) {
-	p.logger = logger
-}
-
-// BrokerHostServices is called by the framework when the plugin is loaded to
-// give the plugin a chance to obtain clients to SPIRE host services.
-// TODO: Remove if the plugin does not need host services.
-func (p *Plugin) BrokerHostServices(broker pluginsdk.ServiceBroker) error {
-	// TODO: Use the broker to obtain host service clients
-	return nil
-}
-
-// DeleteX509SVID implements the SVIDStore DeleteX509SVID RPC
+// DeleteX509SVID implements the SVIDStore DeleteX509SVID RPC. Puts an X509-SVID in a configured secrets store.
 func (p *Plugin) DeleteX509SVID(ctx context.Context, req *svidstorev1.DeleteX509SVIDRequest) (*svidstorev1.DeleteX509SVIDResponse, error) {
 	config, err := p.getConfig()
 	if err != nil {
@@ -80,7 +65,7 @@ func (p *Plugin) DeleteX509SVID(ctx context.Context, req *svidstorev1.DeleteX509
 	return nil, status.Error(codes.Unimplemented, "not implemented")
 }
 
-// PutX509SVID implements the SVIDStore PutX509SVID RPC
+// PutX509SVID implements the SVIDStore PutX509SVID RPC. Deletes an SVID from the store
 func (p *Plugin) PutX509SVID(ctx context.Context, req *svidstorev1.PutX509SVIDRequest) (*svidstorev1.PutX509SVIDResponse, error) {
 	config, err := p.getConfig()
 	if err != nil {
@@ -93,6 +78,21 @@ func (p *Plugin) PutX509SVID(ctx context.Context, req *svidstorev1.PutX509SVIDRe
 	config = config
 
 	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+// SetLogger is called by the framework when the plugin is loaded and provides
+// the plugin with a logger wired up to SPIRE's logging facilities.
+// TODO: Remove if the plugin does not need the logger.
+func (p *Plugin) SetLogger(logger hclog.Logger) {
+	p.logger = logger
+}
+
+// BrokerHostServices is called by the framework when the plugin is loaded to
+// give the plugin a chance to obtain clients to SPIRE host services.
+// TODO: Remove if the plugin does not need host services.
+func (p *Plugin) BrokerHostServices(broker pluginsdk.ServiceBroker) error {
+	// TODO: Use the broker to obtain host service clients
+	return nil
 }
 
 // Configure configures the plugin. This is invoked by SPIRE when the plugin is

--- a/templates/agent/svidstore/svidstore.go
+++ b/templates/agent/svidstore/svidstore.go
@@ -96,7 +96,7 @@ func (p *Plugin) PutX509SVID(ctx context.Context, req *svidstorev1.PutX509SVIDRe
 }
 
 // Configure configures the plugin. This is invoked by SPIRE when the plugin is
-// first loaded. In the future, tt may be invoked to reconfigure the plugin.
+// first loaded. In the future, it may be invoked to reconfigure the plugin.
 // As such, it should replace the previous configuration atomically.
 // TODO: Remove if no configuration is required
 func (p *Plugin) Configure(ctx context.Context, req *configv1.ConfigureRequest) (*configv1.ConfigureResponse, error) {

--- a/templates/agent/svidstore/svidstore.go
+++ b/templates/agent/svidstore/svidstore.go
@@ -15,12 +15,12 @@ import (
 )
 
 var (
-	// This compile time assertion ensures the plugin conforms properly to the
+	// This compile-time assertion ensures the plugin conforms properly to the
 	// pluginsdk.NeedsLogger interface.
 	// TODO: Remove if the plugin does not need the logger.
 	_ pluginsdk.NeedsLogger = (*Plugin)(nil)
 
-	// This compile time assertion ensures the plugin conforms properly to the
+	// This compile-time assertion ensures the plugin conforms properly to the
 	// pluginsdk.NeedsHostServices interface.
 	// TODO: Remove if the plugin does not need host services.
 	_ pluginsdk.NeedsHostServices = (*Plugin)(nil)
@@ -80,14 +80,6 @@ func (p *Plugin) PutX509SVID(ctx context.Context, req *svidstorev1.PutX509SVIDRe
 	return nil, status.Error(codes.Unimplemented, "not implemented")
 }
 
-// BrokerHostServices is called by the framework when the plugin is loaded to
-// give the plugin a chance to obtain clients to SPIRE host services.
-// TODO: Remove if the plugin does not need host services.
-func (p *Plugin) BrokerHostServices(broker pluginsdk.ServiceBroker) error {
-	// TODO: Use the broker to obtain host service clients
-	return nil
-}
-
 // Configure configures the plugin. This is invoked by SPIRE when the plugin is
 // first loaded. In the future, it may be invoked to reconfigure the plugin.
 // As such, it should replace the previous configuration atomically.
@@ -103,6 +95,14 @@ func (p *Plugin) Configure(ctx context.Context, req *configv1.ConfigureRequest) 
 
 	p.setConfig(config)
 	return &configv1.ConfigureResponse{}, nil
+}
+
+// BrokerHostServices is called by the framework when the plugin is loaded to
+// give the plugin a chance to obtain clients to SPIRE host services.
+// TODO: Remove if the plugin does not need host services.
+func (p *Plugin) BrokerHostServices(broker pluginsdk.ServiceBroker) error {
+	// TODO: Use the broker to obtain host service clients
+	return nil
 }
 
 // SetLogger is called by the framework when the plugin is loaded and provides

--- a/templates/agent/svidstore/svidstore_test.go
+++ b/templates/agent/svidstore/svidstore_test.go
@@ -1,6 +1,7 @@
 package svidstore_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/spiffe/spire-plugin-sdk/pluginsdk"
@@ -8,6 +9,8 @@ import (
 	svidstorev1 "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/agent/svidstore/v1"
 	configv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/service/common/config/v1"
 	"github.com/spiffe/spire-plugin-sdk/templates/agent/svidstore"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test(t *testing.T) {
@@ -32,5 +35,20 @@ func Test(t *testing.T) {
 		},
 	})
 
-	// TODO: Invoke methods on the clients and assert the results
+	ctx := context.Background()
+
+	// TODO: Remove if no configuration is required.
+	_, err := configClient.Configure(ctx, &configv1.ConfigureRequest{
+		CoreConfiguration: &configv1.CoreConfiguration{TrustDomain: "example.org"},
+		HclConfiguration:  `{}`,
+	})
+	assert.NoError(t, err)
+
+	require.True(t, ssClient.IsInitialized())
+
+	// TODO: Make assertions using the desired plugin behavior.
+	_, err = ssClient.PutX509SVID(ctx, &svidstorev1.PutX509SVIDRequest{})
+	assert.EqualError(t, err, "rpc error: code = Unimplemented desc = not implemented")
+	_, err = ssClient.DeleteX509SVID(ctx, &svidstorev1.DeleteX509SVIDRequest{})
+	assert.EqualError(t, err, "rpc error: code = Unimplemented desc = not implemented")
 }

--- a/templates/agent/svidstore/svidstore_test.go
+++ b/templates/agent/svidstore/svidstore_test.go
@@ -45,7 +45,6 @@ func Test(t *testing.T) {
 	assert.NoError(t, err)
 
 	require.True(t, ssClient.IsInitialized())
-
 	// TODO: Make assertions using the desired plugin behavior.
 	_, err = ssClient.PutX509SVID(ctx, &svidstorev1.PutX509SVIDRequest{})
 	assert.EqualError(t, err, "rpc error: code = Unimplemented desc = not implemented")

--- a/templates/agent/workloadattestor/workloadattestor.go
+++ b/templates/agent/workloadattestor/workloadattestor.go
@@ -50,6 +50,25 @@ type Plugin struct {
 	logger hclog.Logger
 }
 
+// Attest implements the WorkloadAttestor Attest RPC. Attests the specified workload process. If the process is not one
+// the attestor is in a position to attest (e.g. k8s attestor attesting a non-k8s workload), the call will succeed but
+// return no selectors. If the process is one of the attestor is in a position to attest, but the attestor fails to
+// gather all selectors related to that workload, the call will fail. Otherwise, the attestor will return one or more
+// workload selectors.
+func (p *Plugin) Attest(ctx context.Context, req *workloadattestorv1.AttestRequest) (*workloadattestorv1.AttestResponse, error) {
+	config, err := p.getConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: Implement the RPC behavior. The following line silences compiler
+	// warnings and can be removed once the configuration is referenced by the
+	// implementation.
+	config = config
+
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
 // SetLogger is called by the framework when the plugin is loaded and provides
 // the plugin with a logger wired up to SPIRE's logging facilities.
 // TODO: Remove if the plugin does not need the logger.
@@ -63,21 +82,6 @@ func (p *Plugin) SetLogger(logger hclog.Logger) {
 func (p *Plugin) BrokerHostServices(broker pluginsdk.ServiceBroker) error {
 	// TODO: Use the broker to obtain host service clients
 	return nil
-}
-
-// Attest implements the WorkloadAttestor Attest RPC
-func (p *Plugin) Attest(ctx context.Context, req *workloadattestorv1.AttestRequest) (*workloadattestorv1.AttestResponse, error) {
-	config, err := p.getConfig()
-	if err != nil {
-		return nil, err
-	}
-
-	// TODO: Implement the RPC behavior. The following line silences compiler
-	// warnings and can be removed once the configuration is referenced by the
-	// implementation.
-	config = config
-
-	return nil, status.Error(codes.Unimplemented, "not implemented")
 }
 
 // Configure configures the plugin. This is invoked by SPIRE when the plugin is

--- a/templates/agent/workloadattestor/workloadattestor.go
+++ b/templates/agent/workloadattestor/workloadattestor.go
@@ -81,7 +81,7 @@ func (p *Plugin) Attest(ctx context.Context, req *workloadattestorv1.AttestReque
 }
 
 // Configure configures the plugin. This is invoked by SPIRE when the plugin is
-// first loaded. In the future, tt may be invoked to reconfigure the plugin.
+// first loaded. In the future, it may be invoked to reconfigure the plugin.
 // As such, it should replace the previous configuration atomically.
 // TODO: Remove if no configuration is required
 func (p *Plugin) Configure(ctx context.Context, req *configv1.ConfigureRequest) (*configv1.ConfigureResponse, error) {

--- a/templates/agent/workloadattestor/workloadattestor.go
+++ b/templates/agent/workloadattestor/workloadattestor.go
@@ -15,12 +15,12 @@ import (
 )
 
 var (
-	// This compile time assertion ensures the plugin conforms properly to the
+	// This compile-time assertion ensures the plugin conforms properly to the
 	// pluginsdk.NeedsLogger interface.
 	// TODO: Remove if the plugin does not need the logger.
 	_ pluginsdk.NeedsLogger = (*Plugin)(nil)
 
-	// This compile time assertion ensures the plugin conforms properly to the
+	// This compile-time assertion ensures the plugin conforms properly to the
 	// pluginsdk.NeedsHostServices interface.
 	// TODO: Remove if the plugin does not need host services.
 	_ pluginsdk.NeedsHostServices = (*Plugin)(nil)
@@ -69,14 +69,6 @@ func (p *Plugin) Attest(ctx context.Context, req *workloadattestorv1.AttestReque
 	return nil, status.Error(codes.Unimplemented, "not implemented")
 }
 
-// BrokerHostServices is called by the framework when the plugin is loaded to
-// give the plugin a chance to obtain clients to SPIRE host services.
-// TODO: Remove if the plugin does not need host services.
-func (p *Plugin) BrokerHostServices(broker pluginsdk.ServiceBroker) error {
-	// TODO: Use the broker to obtain host service clients
-	return nil
-}
-
 // Configure configures the plugin. This is invoked by SPIRE when the plugin is
 // first loaded. In the future, it may be invoked to reconfigure the plugin.
 // As such, it should replace the previous configuration atomically.
@@ -92,6 +84,14 @@ func (p *Plugin) Configure(ctx context.Context, req *configv1.ConfigureRequest) 
 
 	p.setConfig(config)
 	return &configv1.ConfigureResponse{}, nil
+}
+
+// BrokerHostServices is called by the framework when the plugin is loaded to
+// give the plugin a chance to obtain clients to SPIRE host services.
+// TODO: Remove if the plugin does not need host services.
+func (p *Plugin) BrokerHostServices(broker pluginsdk.ServiceBroker) error {
+	// TODO: Use the broker to obtain host service clients
+	return nil
 }
 
 // SetLogger is called by the framework when the plugin is loaded and provides

--- a/templates/agent/workloadattestor/workloadattestor.go
+++ b/templates/agent/workloadattestor/workloadattestor.go
@@ -69,13 +69,6 @@ func (p *Plugin) Attest(ctx context.Context, req *workloadattestorv1.AttestReque
 	return nil, status.Error(codes.Unimplemented, "not implemented")
 }
 
-// SetLogger is called by the framework when the plugin is loaded and provides
-// the plugin with a logger wired up to SPIRE's logging facilities.
-// TODO: Remove if the plugin does not need the logger.
-func (p *Plugin) SetLogger(logger hclog.Logger) {
-	p.logger = logger
-}
-
 // BrokerHostServices is called by the framework when the plugin is loaded to
 // give the plugin a chance to obtain clients to SPIRE host services.
 // TODO: Remove if the plugin does not need host services.
@@ -99,6 +92,13 @@ func (p *Plugin) Configure(ctx context.Context, req *configv1.ConfigureRequest) 
 
 	p.setConfig(config)
 	return &configv1.ConfigureResponse{}, nil
+}
+
+// SetLogger is called by the framework when the plugin is loaded and provides
+// the plugin with a logger wired up to SPIRE's logging facilities.
+// TODO: Remove if the plugin does not need the logger.
+func (p *Plugin) SetLogger(logger hclog.Logger) {
+	p.logger = logger
 }
 
 // setConfig replaces the configuration atomically under a write lock.

--- a/templates/agent/workloadattestor/workloadattestor_test.go
+++ b/templates/agent/workloadattestor/workloadattestor_test.go
@@ -45,7 +45,6 @@ func Test(t *testing.T) {
 	assert.NoError(t, err)
 
 	require.True(t, waClient.IsInitialized())
-
 	// TODO: Make assertions using the desired plugin behavior.
 	_, err = waClient.Attest(ctx, &workloadattestorv1.AttestRequest{})
 	assert.EqualError(t, err, "rpc error: code = Unimplemented desc = not implemented")

--- a/templates/agent/workloadattestor/workloadattestor_test.go
+++ b/templates/agent/workloadattestor/workloadattestor_test.go
@@ -1,6 +1,7 @@
 package workloadattestor_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/spiffe/spire-plugin-sdk/pluginsdk"
@@ -8,6 +9,8 @@ import (
 	workloadattestorv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/agent/workloadattestor/v1"
 	configv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/service/common/config/v1"
 	"github.com/spiffe/spire-plugin-sdk/templates/agent/workloadattestor"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test(t *testing.T) {
@@ -32,5 +35,18 @@ func Test(t *testing.T) {
 		},
 	})
 
-	// TODO: Invoke methods on the clients and assert the results
+	ctx := context.Background()
+
+	// TODO: Remove if no configuration is required.
+	_, err := configClient.Configure(ctx, &configv1.ConfigureRequest{
+		CoreConfiguration: &configv1.CoreConfiguration{TrustDomain: "example.org"},
+		HclConfiguration:  `{}`,
+	})
+	assert.NoError(t, err)
+
+	require.True(t, waClient.IsInitialized())
+
+	// TODO: Make assertions using the desired plugin behavior.
+	_, err = waClient.Attest(ctx, &workloadattestorv1.AttestRequest{})
+	assert.EqualError(t, err, "rpc error: code = Unimplemented desc = not implemented")
 }

--- a/templates/agent/workloadattestor/workloadattestor_test.go
+++ b/templates/agent/workloadattestor/workloadattestor_test.go
@@ -35,7 +35,8 @@ func Test(t *testing.T) {
 		},
 	})
 
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	// TODO: Remove if no configuration is required.
 	_, err := configClient.Configure(ctx, &configv1.ConfigureRequest{

--- a/templates/server/credentialcomposer/credentialcomposer.go
+++ b/templates/server/credentialcomposer/credentialcomposer.go
@@ -144,13 +144,6 @@ func (p *Plugin) ComposeWorkloadJWTSVID(ctx context.Context, req *credentialcomp
 	return nil, status.Error(codes.Unimplemented, "not implemented")
 }
 
-// SetLogger is called by the framework when the plugin is loaded and provides
-// the plugin with a logger wired up to SPIRE's logging facilities.
-// TODO: Remove if the plugin does not need the logger.
-func (p *Plugin) SetLogger(logger hclog.Logger) {
-	p.logger = logger
-}
-
 // BrokerHostServices is called by the framework when the plugin is loaded to
 // give the plugin a chance to obtain clients to SPIRE host services.
 // TODO: Remove if the plugin does not need host services.
@@ -174,6 +167,13 @@ func (p *Plugin) Configure(ctx context.Context, req *configv1.ConfigureRequest) 
 
 	p.setConfig(config)
 	return &configv1.ConfigureResponse{}, nil
+}
+
+// SetLogger is called by the framework when the plugin is loaded and provides
+// the plugin with a logger wired up to SPIRE's logging facilities.
+// TODO: Remove if the plugin does not need the logger.
+func (p *Plugin) SetLogger(logger hclog.Logger) {
+	p.logger = logger
 }
 
 // setConfig replaces the configuration atomically under a write lock.

--- a/templates/server/credentialcomposer/credentialcomposer.go
+++ b/templates/server/credentialcomposer/credentialcomposer.go
@@ -15,12 +15,12 @@ import (
 )
 
 var (
-	// This compile time assertion ensures the plugin conforms properly to the
+	// This compile-time assertion ensures the plugin conforms properly to the
 	// pluginsdk.NeedsLogger interface.
 	// TODO: Remove if the plugin does not need the logger.
 	_ pluginsdk.NeedsLogger = (*Plugin)(nil)
 
-	// This compile time assertion ensures the plugin conforms properly to the
+	// This compile-time assertion ensures the plugin conforms properly to the
 	// pluginsdk.NeedsHostServices interface.
 	// TODO: Remove if the plugin does not need host services.
 	_ pluginsdk.NeedsHostServices = (*Plugin)(nil)
@@ -144,14 +144,6 @@ func (p *Plugin) ComposeWorkloadJWTSVID(ctx context.Context, req *credentialcomp
 	return nil, status.Error(codes.Unimplemented, "not implemented")
 }
 
-// BrokerHostServices is called by the framework when the plugin is loaded to
-// give the plugin a chance to obtain clients to SPIRE host services.
-// TODO: Remove if the plugin does not need host services.
-func (p *Plugin) BrokerHostServices(broker pluginsdk.ServiceBroker) error {
-	// TODO: Use the broker to obtain host service clients
-	return nil
-}
-
 // Configure configures the plugin. This is invoked by SPIRE when the plugin is
 // first loaded. In the future, it may be invoked to reconfigure the plugin.
 // As such, it should replace the previous configuration atomically.
@@ -167,6 +159,14 @@ func (p *Plugin) Configure(ctx context.Context, req *configv1.ConfigureRequest) 
 
 	p.setConfig(config)
 	return &configv1.ConfigureResponse{}, nil
+}
+
+// BrokerHostServices is called by the framework when the plugin is loaded to
+// give the plugin a chance to obtain clients to SPIRE host services.
+// TODO: Remove if the plugin does not need host services.
+func (p *Plugin) BrokerHostServices(broker pluginsdk.ServiceBroker) error {
+	// TODO: Use the broker to obtain host service clients
+	return nil
 }
 
 // SetLogger is called by the framework when the plugin is loaded and provides

--- a/templates/server/credentialcomposer/credentialcomposer.go
+++ b/templates/server/credentialcomposer/credentialcomposer.go
@@ -135,7 +135,7 @@ func (p *Plugin) ComposeWorkloadJWTSVID(ctx context.Context, req *credentialcomp
 }
 
 // Configure configures the plugin. This is invoked by SPIRE when the plugin is
-// first loaded. In the future, tt may be invoked to reconfigure the plugin.
+// first loaded. In the future, it may be invoked to reconfigure the plugin.
 // As such, it should replace the previous configuration atomically.
 // TODO: Remove if no configuration is required
 func (p *Plugin) Configure(ctx context.Context, req *configv1.ConfigureRequest) (*configv1.ConfigureResponse, error) {

--- a/templates/server/credentialcomposer/credentialcomposer.go
+++ b/templates/server/credentialcomposer/credentialcomposer.go
@@ -50,21 +50,10 @@ type Plugin struct {
 	logger hclog.Logger
 }
 
-// SetLogger is called by the framework when the plugin is loaded and provides
-// the plugin with a logger wired up to SPIRE's logging facilities.
-// TODO: Remove if the plugin does not need the logger.
-func (p *Plugin) SetLogger(logger hclog.Logger) {
-	p.logger = logger
-}
-
-// BrokerHostServices is called by the framework when the plugin is loaded to
-// give the plugin a chance to obtain clients to SPIRE host services.
-// TODO: Remove if the plugin does not need host services.
-func (p *Plugin) BrokerHostServices(broker pluginsdk.ServiceBroker) error {
-	// TODO: Use the broker to obtain host service clients
-	return nil
-}
-
+// ComposeServerX509CA implements the CredentialComposer ComposeServerX509CA RPC. Composes the SPIRE Server X509 CA.
+// The server will supply the default attributes it will apply to the CA. If the plugin returns an empty response or
+// NOT_IMPLEMENTED, the server will apply the default attributes. Otherwise, the returned attributes are used.
+// If a CA is produced that does not conform to the SPIFFE X509-SVID specification for signing certificates, it will be rejected.
 func (p *Plugin) ComposeServerX509CA(ctx context.Context, req *credentialcomposerv1.ComposeServerX509CARequest) (*credentialcomposerv1.ComposeServerX509CAResponse, error) {
 	config, err := p.getConfig()
 	if err != nil {
@@ -79,6 +68,11 @@ func (p *Plugin) ComposeServerX509CA(ctx context.Context, req *credentialcompose
 	return nil, status.Error(codes.Unimplemented, "not implemented")
 }
 
+// ComposeServerX509SVID implements the CredentialComposer ComposeServerX509SVID RPC. Composes the SPIRE Server X509-SVID.
+// The server will supply the default attributes it will apply to the server X509-SVID. If the plugin returns an empty
+// response or NOT_IMPLEMENTED, the server will apply the default attributes. Otherwise, the returned attributes are
+// used. If an X509-SVID is produced that does not conform to the SPIFFE X509-SVID specification for leaf certificates,
+// it will be rejected. This function cannot be used to modify the SPIFFE ID of the X509-SVID.
 func (p *Plugin) ComposeServerX509SVID(ctx context.Context, req *credentialcomposerv1.ComposeServerX509SVIDRequest) (*credentialcomposerv1.ComposeServerX509SVIDResponse, error) {
 	config, err := p.getConfig()
 	if err != nil {
@@ -93,6 +87,11 @@ func (p *Plugin) ComposeServerX509SVID(ctx context.Context, req *credentialcompo
 	return nil, status.Error(codes.Unimplemented, "not implemented")
 }
 
+// ComposeAgentX509SVID implements the CredentialComposer ComposeAgentX509SVID RPC. Composes the SPIRE Agent X509-SVID.
+// The server will supply the default attributes it will apply to the agent X509-SVID. If the plugin returns an empty
+// response or NOT_IMPLEMENTED, the server will apply the default attributes. Otherwise, the returned attributes are used.
+// If an X509-SVID is produced that does not conform to the SPIFFE X509-SVID specification for leaf certificates, it will
+// be rejected. This function cannot be used to modify the SPIFFE ID of the X509-SVID.
 func (p *Plugin) ComposeAgentX509SVID(ctx context.Context, req *credentialcomposerv1.ComposeAgentX509SVIDRequest) (*credentialcomposerv1.ComposeAgentX509SVIDResponse, error) {
 	config, err := p.getConfig()
 	if err != nil {
@@ -107,6 +106,11 @@ func (p *Plugin) ComposeAgentX509SVID(ctx context.Context, req *credentialcompos
 	return nil, status.Error(codes.Unimplemented, "not implemented")
 }
 
+// ComposeWorkloadX509SVID implements the CredentialComposer ComposeWorkloadX509SVID RPC. Composes workload X509-SVIDs.
+// The server will supply the default attributes it will apply to the workload X509-SVID. If the plugin returns an empty
+// response or NOT_IMPLEMENTED, the server will apply the default attributes. Otherwise, the returned attributes are used.
+// If an X509-SVID is produced that does not conform to the SPIFFE X509-SVID specification for leaf certificates, it will
+// be rejected. This function cannot be used to modify the SPIFFE ID of the X509-SVID.
 func (p *Plugin) ComposeWorkloadX509SVID(ctx context.Context, req *credentialcomposerv1.ComposeWorkloadX509SVIDRequest) (*credentialcomposerv1.ComposeWorkloadX509SVIDResponse, error) {
 	config, err := p.getConfig()
 	if err != nil {
@@ -120,6 +124,12 @@ func (p *Plugin) ComposeWorkloadX509SVID(ctx context.Context, req *credentialcom
 
 	return nil, status.Error(codes.Unimplemented, "not implemented")
 }
+
+// ComposeWorkloadJWTSVID implements the CredentialComposer ComposeWorkloadJWTSVID RPC. Composes workload JWT-SVIDs.
+// The server will supply the default attributes it will apply to the workload JWT-SVID. If the plugin returns an empty
+// response or NOT_IMPLEMENTED, the server will apply the default attributes. Otherwise, the returned attributes are used.
+// If a JWT-SVID is produced that does not conform to the SPIFFE JWT-SVID specification, it will be rejected.
+// This function cannot be used to modify the SPIFFE ID of the JWT-SVID.
 func (p *Plugin) ComposeWorkloadJWTSVID(ctx context.Context, req *credentialcomposerv1.ComposeWorkloadJWTSVIDRequest) (*credentialcomposerv1.ComposeWorkloadJWTSVIDResponse, error) {
 	config, err := p.getConfig()
 	if err != nil {
@@ -132,6 +142,21 @@ func (p *Plugin) ComposeWorkloadJWTSVID(ctx context.Context, req *credentialcomp
 	config = config
 
 	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+// SetLogger is called by the framework when the plugin is loaded and provides
+// the plugin with a logger wired up to SPIRE's logging facilities.
+// TODO: Remove if the plugin does not need the logger.
+func (p *Plugin) SetLogger(logger hclog.Logger) {
+	p.logger = logger
+}
+
+// BrokerHostServices is called by the framework when the plugin is loaded to
+// give the plugin a chance to obtain clients to SPIRE host services.
+// TODO: Remove if the plugin does not need host services.
+func (p *Plugin) BrokerHostServices(broker pluginsdk.ServiceBroker) error {
+	// TODO: Use the broker to obtain host service clients
+	return nil
 }
 
 // Configure configures the plugin. This is invoked by SPIRE when the plugin is

--- a/templates/server/credentialcomposer/credentialcomposer_test.go
+++ b/templates/server/credentialcomposer/credentialcomposer_test.go
@@ -1,6 +1,7 @@
 package credentialcomposer_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/spiffe/spire-plugin-sdk/pluginsdk"
@@ -8,6 +9,8 @@ import (
 	credentialcomposerv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/server/credentialcomposer/v1"
 	configv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/service/common/config/v1"
 	"github.com/spiffe/spire-plugin-sdk/templates/server/credentialcomposer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test(t *testing.T) {
@@ -32,5 +35,25 @@ func Test(t *testing.T) {
 		},
 	})
 
-	// TODO: Invoke methods on the clients and assert the results
+	ctx := context.Background()
+
+	// TODO: Remove if no configuration is required.
+	_, err := configClient.Configure(ctx, &configv1.ConfigureRequest{
+		CoreConfiguration: &configv1.CoreConfiguration{TrustDomain: "example.org"},
+		HclConfiguration:  `{}`,
+	})
+	assert.NoError(t, err)
+
+	require.True(t, pluginClient.IsInitialized())
+	// TODO: Make assertions using the desired plugin behavior.
+	_, err = pluginClient.ComposeServerX509CA(ctx, &credentialcomposerv1.ComposeServerX509CARequest{})
+	assert.EqualError(t, err, "rpc error: code = Unimplemented desc = not implemented")
+	_, err = pluginClient.ComposeServerX509SVID(ctx, &credentialcomposerv1.ComposeServerX509SVIDRequest{})
+	assert.EqualError(t, err, "rpc error: code = Unimplemented desc = not implemented")
+	_, err = pluginClient.ComposeAgentX509SVID(ctx, &credentialcomposerv1.ComposeAgentX509SVIDRequest{})
+	assert.EqualError(t, err, "rpc error: code = Unimplemented desc = not implemented")
+	_, err = pluginClient.ComposeWorkloadX509SVID(ctx, &credentialcomposerv1.ComposeWorkloadX509SVIDRequest{})
+	assert.EqualError(t, err, "rpc error: code = Unimplemented desc = not implemented")
+	_, err = pluginClient.ComposeWorkloadJWTSVID(ctx, &credentialcomposerv1.ComposeWorkloadJWTSVIDRequest{})
+	assert.EqualError(t, err, "rpc error: code = Unimplemented desc = not implemented")
 }

--- a/templates/server/keymanager/keymanager.go
+++ b/templates/server/keymanager/keymanager.go
@@ -15,12 +15,12 @@ import (
 )
 
 var (
-	// This compile time assertion ensures the plugin conforms properly to the
+	// This compile-time assertion ensures the plugin conforms properly to the
 	// pluginsdk.NeedsLogger interface.
 	// TODO: Remove if the plugin does not need the logger.
 	_ pluginsdk.NeedsLogger = (*Plugin)(nil)
 
-	// This compile time assertion ensures the plugin conforms properly to the
+	// This compile-time assertion ensures the plugin conforms properly to the
 	// pluginsdk.NeedsHostServices interface.
 	// TODO: Remove if the plugin does not need host services.
 	_ pluginsdk.NeedsHostServices = (*Plugin)(nil)
@@ -115,14 +115,6 @@ func (p *Plugin) SignData(ctx context.Context, req *keymanagerv1.SignDataRequest
 	return nil, status.Error(codes.Unimplemented, "not implemented")
 }
 
-// BrokerHostServices is called by the framework when the plugin is loaded to
-// give the plugin a chance to obtain clients to SPIRE host services.
-// TODO: Remove if the plugin does not need host services.
-func (p *Plugin) BrokerHostServices(broker pluginsdk.ServiceBroker) error {
-	// TODO: Use the broker to obtain host service clients
-	return nil
-}
-
 // Configure configures the plugin. This is invoked by SPIRE when the plugin is
 // first loaded. In the future, it may be invoked to reconfigure the plugin.
 // As such, it should replace the previous configuration atomically.
@@ -138,6 +130,14 @@ func (p *Plugin) Configure(ctx context.Context, req *configv1.ConfigureRequest) 
 
 	p.setConfig(config)
 	return &configv1.ConfigureResponse{}, nil
+}
+
+// BrokerHostServices is called by the framework when the plugin is loaded to
+// give the plugin a chance to obtain clients to SPIRE host services.
+// TODO: Remove if the plugin does not need host services.
+func (p *Plugin) BrokerHostServices(broker pluginsdk.ServiceBroker) error {
+	// TODO: Use the broker to obtain host service clients
+	return nil
 }
 
 // SetLogger is called by the framework when the plugin is loaded and provides

--- a/templates/server/keymanager/keymanager.go
+++ b/templates/server/keymanager/keymanager.go
@@ -50,22 +50,8 @@ type Plugin struct {
 	logger hclog.Logger
 }
 
-// SetLogger is called by the framework when the plugin is loaded and provides
-// the plugin with a logger wired up to SPIRE's logging facilities.
-// TODO: Remove if the plugin does not need the logger.
-func (p *Plugin) SetLogger(logger hclog.Logger) {
-	p.logger = logger
-}
-
-// BrokerHostServices is called by the framework when the plugin is loaded to
-// give the plugin a chance to obtain clients to SPIRE host services.
-// TODO: Remove if the plugin does not need host services.
-func (p *Plugin) BrokerHostServices(broker pluginsdk.ServiceBroker) error {
-	// TODO: Use the broker to obtain host service clients
-	return nil
-}
-
-// GenerateKey implements the KeyManager GenerateKey RPC
+// GenerateKey implements the KeyManager GenerateKey RPC. Generates a new private key with the given ID.
+// If a key already exists under that ID, it is overwritten and given a different fingerprint.
 func (p *Plugin) GenerateKey(ctx context.Context, req *keymanagerv1.GenerateKeyRequest) (*keymanagerv1.GenerateKeyResponse, error) {
 	config, err := p.getConfig()
 	if err != nil {
@@ -80,7 +66,8 @@ func (p *Plugin) GenerateKey(ctx context.Context, req *keymanagerv1.GenerateKeyR
 	return nil, status.Error(codes.Unimplemented, "not implemented")
 }
 
-// GetPublicKey implements the KeyManager GetPublicKey RPC
+// GetPublicKey implements the KeyManager GetPublicKey RPC. Gets the public key information for the private key managed
+// by the plugin with the given ID. If a key with the given ID does not exist, NOT_FOUND is returned.
 func (p *Plugin) GetPublicKey(ctx context.Context, req *keymanagerv1.GetPublicKeyRequest) (*keymanagerv1.GetPublicKeyResponse, error) {
 	config, err := p.getConfig()
 	if err != nil {
@@ -95,7 +82,8 @@ func (p *Plugin) GetPublicKey(ctx context.Context, req *keymanagerv1.GetPublicKe
 	return nil, status.Error(codes.Unimplemented, "not implemented")
 }
 
-// GetPublicKeys implements the KeyManager GetPublicKeys RPC
+// GetPublicKeys implements the KeyManager GetPublicKeys RPC. Gets all public key information for the private keys
+// managed by the plugin.
 func (p *Plugin) GetPublicKeys(ctx context.Context, req *keymanagerv1.GetPublicKeysRequest) (*keymanagerv1.GetPublicKeysResponse, error) {
 	config, err := p.getConfig()
 	if err != nil {
@@ -110,7 +98,9 @@ func (p *Plugin) GetPublicKeys(ctx context.Context, req *keymanagerv1.GetPublicK
 	return nil, status.Error(codes.Unimplemented, "not implemented")
 }
 
-// SignData implements the KeyManager SignData RPC
+// SignData implements the KeyManager SignData RPC. Signs data with the private key identified by the given ID. If a key
+// with the given ID does not exist, NOT_FOUND is returned. The response contains the signed data and the fingerprint of
+// the key used to sign the data. See the PublicKey message for more details on the role of the fingerprint.
 func (p *Plugin) SignData(ctx context.Context, req *keymanagerv1.SignDataRequest) (*keymanagerv1.SignDataResponse, error) {
 	config, err := p.getConfig()
 	if err != nil {
@@ -123,6 +113,21 @@ func (p *Plugin) SignData(ctx context.Context, req *keymanagerv1.SignDataRequest
 	config = config
 
 	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+// SetLogger is called by the framework when the plugin is loaded and provides
+// the plugin with a logger wired up to SPIRE's logging facilities.
+// TODO: Remove if the plugin does not need the logger.
+func (p *Plugin) SetLogger(logger hclog.Logger) {
+	p.logger = logger
+}
+
+// BrokerHostServices is called by the framework when the plugin is loaded to
+// give the plugin a chance to obtain clients to SPIRE host services.
+// TODO: Remove if the plugin does not need host services.
+func (p *Plugin) BrokerHostServices(broker pluginsdk.ServiceBroker) error {
+	// TODO: Use the broker to obtain host service clients
+	return nil
 }
 
 // Configure configures the plugin. This is invoked by SPIRE when the plugin is

--- a/templates/server/keymanager/keymanager.go
+++ b/templates/server/keymanager/keymanager.go
@@ -115,13 +115,6 @@ func (p *Plugin) SignData(ctx context.Context, req *keymanagerv1.SignDataRequest
 	return nil, status.Error(codes.Unimplemented, "not implemented")
 }
 
-// SetLogger is called by the framework when the plugin is loaded and provides
-// the plugin with a logger wired up to SPIRE's logging facilities.
-// TODO: Remove if the plugin does not need the logger.
-func (p *Plugin) SetLogger(logger hclog.Logger) {
-	p.logger = logger
-}
-
 // BrokerHostServices is called by the framework when the plugin is loaded to
 // give the plugin a chance to obtain clients to SPIRE host services.
 // TODO: Remove if the plugin does not need host services.
@@ -145,6 +138,13 @@ func (p *Plugin) Configure(ctx context.Context, req *configv1.ConfigureRequest) 
 
 	p.setConfig(config)
 	return &configv1.ConfigureResponse{}, nil
+}
+
+// SetLogger is called by the framework when the plugin is loaded and provides
+// the plugin with a logger wired up to SPIRE's logging facilities.
+// TODO: Remove if the plugin does not need the logger.
+func (p *Plugin) SetLogger(logger hclog.Logger) {
+	p.logger = logger
 }
 
 // setConfig replaces the configuration atomically under a write lock.

--- a/templates/server/keymanager/keymanager.go
+++ b/templates/server/keymanager/keymanager.go
@@ -126,7 +126,7 @@ func (p *Plugin) SignData(ctx context.Context, req *keymanagerv1.SignDataRequest
 }
 
 // Configure configures the plugin. This is invoked by SPIRE when the plugin is
-// first loaded. In the future, tt may be invoked to reconfigure the plugin.
+// first loaded. In the future, it may be invoked to reconfigure the plugin.
 // As such, it should replace the previous configuration atomically.
 // TODO: Remove if no configuration is required
 func (p *Plugin) Configure(ctx context.Context, req *configv1.ConfigureRequest) (*configv1.ConfigureResponse, error) {

--- a/templates/server/keymanager/keymanager_test.go
+++ b/templates/server/keymanager/keymanager_test.go
@@ -1,6 +1,7 @@
 package keymanager_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/spiffe/spire-plugin-sdk/pluginsdk"
@@ -8,6 +9,8 @@ import (
 	keymanagerv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/server/keymanager/v1"
 	configv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/service/common/config/v1"
 	"github.com/spiffe/spire-plugin-sdk/templates/server/keymanager"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test(t *testing.T) {
@@ -32,5 +35,24 @@ func Test(t *testing.T) {
 		},
 	})
 
-	// TODO: Invoke methods on the clients and assert the results
+	ctx := context.Background()
+
+	// TODO: Remove if no configuration is required.
+	_, err := configClient.Configure(ctx, &configv1.ConfigureRequest{
+		CoreConfiguration: &configv1.CoreConfiguration{TrustDomain: "example.org"},
+		HclConfiguration:  `{}`,
+	})
+	assert.NoError(t, err)
+
+	require.True(t, kmClient.IsInitialized())
+
+	// TODO: Make assertions using the desired plugin behavior.
+	_, err = kmClient.GenerateKey(ctx, &keymanagerv1.GenerateKeyRequest{})
+	assert.EqualError(t, err, "rpc error: code = Unimplemented desc = not implemented")
+	_, err = kmClient.GetPublicKeys(ctx, &keymanagerv1.GetPublicKeysRequest{})
+	assert.EqualError(t, err, "rpc error: code = Unimplemented desc = not implemented")
+	_, err = kmClient.GetPublicKey(ctx, &keymanagerv1.GetPublicKeyRequest{})
+	assert.EqualError(t, err, "rpc error: code = Unimplemented desc = not implemented")
+	_, err = kmClient.SignData(ctx, &keymanagerv1.SignDataRequest{})
+	assert.EqualError(t, err, "rpc error: code = Unimplemented desc = not implemented")
 }

--- a/templates/server/keymanager/keymanager_test.go
+++ b/templates/server/keymanager/keymanager_test.go
@@ -45,7 +45,6 @@ func Test(t *testing.T) {
 	assert.NoError(t, err)
 
 	require.True(t, kmClient.IsInitialized())
-
 	// TODO: Make assertions using the desired plugin behavior.
 	_, err = kmClient.GenerateKey(ctx, &keymanagerv1.GenerateKeyRequest{})
 	assert.EqualError(t, err, "rpc error: code = Unimplemented desc = not implemented")

--- a/templates/server/nodeattestor/nodeattestor.go
+++ b/templates/server/nodeattestor/nodeattestor.go
@@ -67,13 +67,6 @@ func (p *Plugin) Attest(stream nodeattestorv1.NodeAttestor_AttestServer) error {
 	return status.Error(codes.Unimplemented, "not implemented")
 }
 
-// SetLogger is called by the framework when the plugin is loaded and provides
-// the plugin with a logger wired up to SPIRE's logging facilities.
-// TODO: Remove if the plugin does not need the logger.
-func (p *Plugin) SetLogger(logger hclog.Logger) {
-	p.logger = logger
-}
-
 // BrokerHostServices is called by the framework when the plugin is loaded to
 // give the plugin a chance to obtain clients to SPIRE host services.
 // TODO: Remove if the plugin does not need host services.
@@ -97,6 +90,13 @@ func (p *Plugin) Configure(ctx context.Context, req *configv1.ConfigureRequest) 
 
 	p.setConfig(config)
 	return &configv1.ConfigureResponse{}, nil
+}
+
+// SetLogger is called by the framework when the plugin is loaded and provides
+// the plugin with a logger wired up to SPIRE's logging facilities.
+// TODO: Remove if the plugin does not need the logger.
+func (p *Plugin) SetLogger(logger hclog.Logger) {
+	p.logger = logger
 }
 
 // setConfig replaces the configuration atomically under a write lock.

--- a/templates/server/nodeattestor/nodeattestor.go
+++ b/templates/server/nodeattestor/nodeattestor.go
@@ -15,12 +15,12 @@ import (
 )
 
 var (
-	// This compile time assertion ensures the plugin conforms properly to the
+	// This compile-time assertion ensures the plugin conforms properly to the
 	// pluginsdk.NeedsLogger interface.
 	// TODO: Remove if the plugin does not need the logger.
 	_ pluginsdk.NeedsLogger = (*Plugin)(nil)
 
-	// This compile time assertion ensures the plugin conforms properly to the
+	// This compile-time assertion ensures the plugin conforms properly to the
 	// pluginsdk.NeedsHostServices interface.
 	// TODO: Remove if the plugin does not need host services.
 	_ pluginsdk.NeedsHostServices = (*Plugin)(nil)
@@ -67,14 +67,6 @@ func (p *Plugin) Attest(stream nodeattestorv1.NodeAttestor_AttestServer) error {
 	return status.Error(codes.Unimplemented, "not implemented")
 }
 
-// BrokerHostServices is called by the framework when the plugin is loaded to
-// give the plugin a chance to obtain clients to SPIRE host services.
-// TODO: Remove if the plugin does not need host services.
-func (p *Plugin) BrokerHostServices(broker pluginsdk.ServiceBroker) error {
-	// TODO: Use the broker to obtain host service clients
-	return nil
-}
-
 // Configure configures the plugin. This is invoked by SPIRE when the plugin is
 // first loaded. In the future, it may be invoked to reconfigure the plugin.
 // As such, it should replace the previous configuration atomically.
@@ -90,6 +82,14 @@ func (p *Plugin) Configure(ctx context.Context, req *configv1.ConfigureRequest) 
 
 	p.setConfig(config)
 	return &configv1.ConfigureResponse{}, nil
+}
+
+// BrokerHostServices is called by the framework when the plugin is loaded to
+// give the plugin a chance to obtain clients to SPIRE host services.
+// TODO: Remove if the plugin does not need host services.
+func (p *Plugin) BrokerHostServices(broker pluginsdk.ServiceBroker) error {
+	// TODO: Use the broker to obtain host service clients
+	return nil
 }
 
 // SetLogger is called by the framework when the plugin is loaded and provides

--- a/templates/server/nodeattestor/nodeattestor.go
+++ b/templates/server/nodeattestor/nodeattestor.go
@@ -65,7 +65,9 @@ func (p *Plugin) BrokerHostServices(broker pluginsdk.ServiceBroker) error {
 	return nil
 }
 
-// Attest implements the NodeAttestor Attest RPC
+// Attest implements the NodeAttestor Attest RPC. Attest attests attestation payload received from the agent and
+// optionally participates in challenge/response attestation mechanics. This RPC uses a bidirectional stream for
+// communication.
 func (p *Plugin) Attest(stream nodeattestorv1.NodeAttestor_AttestServer) error {
 	config, err := p.getConfig()
 	if err != nil {
@@ -81,7 +83,7 @@ func (p *Plugin) Attest(stream nodeattestorv1.NodeAttestor_AttestServer) error {
 }
 
 // Configure configures the plugin. This is invoked by SPIRE when the plugin is
-// first loaded. In the future, tt may be invoked to reconfigure the plugin.
+// first loaded. In the future, it may be invoked to reconfigure the plugin.
 // As such, it should replace the previous configuration atomically.
 // TODO: Remove if no configuration is required
 func (p *Plugin) Configure(ctx context.Context, req *configv1.ConfigureRequest) (*configv1.ConfigureResponse, error) {

--- a/templates/server/nodeattestor/nodeattestor.go
+++ b/templates/server/nodeattestor/nodeattestor.go
@@ -50,21 +50,6 @@ type Plugin struct {
 	logger hclog.Logger
 }
 
-// SetLogger is called by the framework when the plugin is loaded and provides
-// the plugin with a logger wired up to SPIRE's logging facilities.
-// TODO: Remove if the plugin does not need the logger.
-func (p *Plugin) SetLogger(logger hclog.Logger) {
-	p.logger = logger
-}
-
-// BrokerHostServices is called by the framework when the plugin is loaded to
-// give the plugin a chance to obtain clients to SPIRE host services.
-// TODO: Remove if the plugin does not need host services.
-func (p *Plugin) BrokerHostServices(broker pluginsdk.ServiceBroker) error {
-	// TODO: Use the broker to obtain host service clients
-	return nil
-}
-
 // Attest implements the NodeAttestor Attest RPC. Attest attests attestation payload received from the agent and
 // optionally participates in challenge/response attestation mechanics. This RPC uses a bidirectional stream for
 // communication.
@@ -80,6 +65,21 @@ func (p *Plugin) Attest(stream nodeattestorv1.NodeAttestor_AttestServer) error {
 	config = config
 
 	return status.Error(codes.Unimplemented, "not implemented")
+}
+
+// SetLogger is called by the framework when the plugin is loaded and provides
+// the plugin with a logger wired up to SPIRE's logging facilities.
+// TODO: Remove if the plugin does not need the logger.
+func (p *Plugin) SetLogger(logger hclog.Logger) {
+	p.logger = logger
+}
+
+// BrokerHostServices is called by the framework when the plugin is loaded to
+// give the plugin a chance to obtain clients to SPIRE host services.
+// TODO: Remove if the plugin does not need host services.
+func (p *Plugin) BrokerHostServices(broker pluginsdk.ServiceBroker) error {
+	// TODO: Use the broker to obtain host service clients
+	return nil
 }
 
 // Configure configures the plugin. This is invoked by SPIRE when the plugin is

--- a/templates/server/nodeattestor/nodeattestor_test.go
+++ b/templates/server/nodeattestor/nodeattestor_test.go
@@ -1,6 +1,7 @@
 package nodeattestor_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/spiffe/spire-plugin-sdk/pluginsdk"
@@ -8,6 +9,8 @@ import (
 	nodeattestorv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/server/nodeattestor/v1"
 	configv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/service/common/config/v1"
 	"github.com/spiffe/spire-plugin-sdk/templates/server/nodeattestor"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test(t *testing.T) {
@@ -32,5 +35,20 @@ func Test(t *testing.T) {
 		},
 	})
 
-	// TODO: Invoke methods on the clients and assert the results
+	ctx := context.Background()
+
+	// TODO: Remove if no configuration is required.
+	_, err := configClient.Configure(ctx, &configv1.ConfigureRequest{
+		CoreConfiguration: &configv1.CoreConfiguration{TrustDomain: "example.org"},
+		HclConfiguration:  `{}`,
+	})
+	assert.NoError(t, err)
+
+	require.True(t, naClient.IsInitialized())
+
+	// TODO: Make assertions using the desired plugin behavior.
+	resp, err := naClient.Attest(context.Background())
+	require.NoError(t, err)
+	_, err = resp.Recv()
+	assert.EqualError(t, err, "rpc error: code = Unimplemented desc = not implemented")
 }

--- a/templates/server/nodeattestor/nodeattestor_test.go
+++ b/templates/server/nodeattestor/nodeattestor_test.go
@@ -47,7 +47,7 @@ func Test(t *testing.T) {
 	require.True(t, naClient.IsInitialized())
 
 	// TODO: Make assertions using the desired plugin behavior.
-	resp, err := naClient.Attest(context.Background())
+	resp, err := naClient.Attest(ctx)
 	require.NoError(t, err)
 	_, err = resp.Recv()
 	assert.EqualError(t, err, "rpc error: code = Unimplemented desc = not implemented")

--- a/templates/server/nodeattestor/nodeattestor_test.go
+++ b/templates/server/nodeattestor/nodeattestor_test.go
@@ -35,7 +35,8 @@ func Test(t *testing.T) {
 		},
 	})
 
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	// TODO: Remove if no configuration is required.
 	_, err := configClient.Configure(ctx, &configv1.ConfigureRequest{
@@ -46,8 +47,8 @@ func Test(t *testing.T) {
 
 	require.True(t, naClient.IsInitialized())
 	// TODO: Make assertions using the desired plugin behavior.
-	resp, err := naClient.Attest(ctx)
+	stream, err := naClient.Attest(ctx)
 	require.NoError(t, err)
-	_, err = resp.Recv()
+	_, err = stream.Recv()
 	assert.EqualError(t, err, "rpc error: code = Unimplemented desc = not implemented")
 }

--- a/templates/server/nodeattestor/nodeattestor_test.go
+++ b/templates/server/nodeattestor/nodeattestor_test.go
@@ -45,7 +45,6 @@ func Test(t *testing.T) {
 	assert.NoError(t, err)
 
 	require.True(t, naClient.IsInitialized())
-
 	// TODO: Make assertions using the desired plugin behavior.
 	resp, err := naClient.Attest(ctx)
 	require.NoError(t, err)

--- a/templates/server/notifier/notifier.go
+++ b/templates/server/notifier/notifier.go
@@ -94,7 +94,7 @@ func (p *Plugin) NotifyAndAdvise(ctx context.Context, req *notifierv1.NotifyAndA
 }
 
 // Configure configures the plugin. This is invoked by SPIRE when the plugin is
-// first loaded. In the future, tt may be invoked to reconfigure the plugin.
+// first loaded. In the future, it may be invoked to reconfigure the plugin.
 // As such, it should replace the previous configuration atomically.
 // TODO: Remove if no configuration is required
 func (p *Plugin) Configure(ctx context.Context, req *configv1.ConfigureRequest) (*configv1.ConfigureResponse, error) {

--- a/templates/server/notifier/notifier.go
+++ b/templates/server/notifier/notifier.go
@@ -50,21 +50,8 @@ type Plugin struct {
 	logger hclog.Logger
 }
 
-// SetLogger is called by the framework when the plugin is loaded and provides
-// the plugin with a logger wired up to SPIRE's logging facilities.
-// TODO: Remove if the plugin does not need the logger.
-func (p *Plugin) SetLogger(logger hclog.Logger) {
-	p.logger = logger
-}
-
-// BrokerHostServices is called by the framework when the plugin is loaded to
-// give the plugin a chance to obtain clients to SPIRE host services.
-// TODO: Remove if the plugin does not need host services.
-func (p *Plugin) BrokerHostServices(broker pluginsdk.ServiceBroker) error {
-	// TODO: Use the broker to obtain host service clients
-	return nil
-}
-
+// Notify implements the Notifier Notify RPC. Notify notifies the plugin that an event occurred. Errors returned by
+// the plugin are logged but otherwise ignored.
 func (p *Plugin) Notify(ctx context.Context, req *notifierv1.NotifyRequest) (*notifierv1.NotifyResponse, error) {
 	config, err := p.getConfig()
 	if err != nil {
@@ -79,6 +66,9 @@ func (p *Plugin) Notify(ctx context.Context, req *notifierv1.NotifyRequest) (*no
 	return nil, status.Error(codes.Unimplemented, "not implemented")
 }
 
+// NotifyAndAdvise implements the Notifier NotifyAndAdvise RPC. NotifyAndAdvise notifies the plugin that an event
+// occurred and waits for a response. Errors returned by the plugin control SPIRE Server behavior.
+// See NotifyAndAdviseRequest for per-event details.
 func (p *Plugin) NotifyAndAdvise(ctx context.Context, req *notifierv1.NotifyAndAdviseRequest) (*notifierv1.NotifyAndAdviseResponse, error) {
 	config, err := p.getConfig()
 	if err != nil {
@@ -91,6 +81,21 @@ func (p *Plugin) NotifyAndAdvise(ctx context.Context, req *notifierv1.NotifyAndA
 	config = config
 
 	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+// SetLogger is called by the framework when the plugin is loaded and provides
+// the plugin with a logger wired up to SPIRE's logging facilities.
+// TODO: Remove if the plugin does not need the logger.
+func (p *Plugin) SetLogger(logger hclog.Logger) {
+	p.logger = logger
+}
+
+// BrokerHostServices is called by the framework when the plugin is loaded to
+// give the plugin a chance to obtain clients to SPIRE host services.
+// TODO: Remove if the plugin does not need host services.
+func (p *Plugin) BrokerHostServices(broker pluginsdk.ServiceBroker) error {
+	// TODO: Use the broker to obtain host service clients
+	return nil
 }
 
 // Configure configures the plugin. This is invoked by SPIRE when the plugin is

--- a/templates/server/notifier/notifier.go
+++ b/templates/server/notifier/notifier.go
@@ -15,12 +15,12 @@ import (
 )
 
 var (
-	// This compile time assertion ensures the plugin conforms properly to the
+	// This compile-time assertion ensures the plugin conforms properly to the
 	// pluginsdk.NeedsLogger interface.
 	// TODO: Remove if the plugin does not need the logger.
 	_ pluginsdk.NeedsLogger = (*Plugin)(nil)
 
-	// This compile time assertion ensures the plugin conforms properly to the
+	// This compile-time assertion ensures the plugin conforms properly to the
 	// pluginsdk.NeedsHostServices interface.
 	// TODO: Remove if the plugin does not need host services.
 	_ pluginsdk.NeedsHostServices = (*Plugin)(nil)
@@ -83,14 +83,6 @@ func (p *Plugin) NotifyAndAdvise(ctx context.Context, req *notifierv1.NotifyAndA
 	return nil, status.Error(codes.Unimplemented, "not implemented")
 }
 
-// BrokerHostServices is called by the framework when the plugin is loaded to
-// give the plugin a chance to obtain clients to SPIRE host services.
-// TODO: Remove if the plugin does not need host services.
-func (p *Plugin) BrokerHostServices(broker pluginsdk.ServiceBroker) error {
-	// TODO: Use the broker to obtain host service clients
-	return nil
-}
-
 // Configure configures the plugin. This is invoked by SPIRE when the plugin is
 // first loaded. In the future, it may be invoked to reconfigure the plugin.
 // As such, it should replace the previous configuration atomically.
@@ -106,6 +98,14 @@ func (p *Plugin) Configure(ctx context.Context, req *configv1.ConfigureRequest) 
 
 	p.setConfig(config)
 	return &configv1.ConfigureResponse{}, nil
+}
+
+// BrokerHostServices is called by the framework when the plugin is loaded to
+// give the plugin a chance to obtain clients to SPIRE host services.
+// TODO: Remove if the plugin does not need host services.
+func (p *Plugin) BrokerHostServices(broker pluginsdk.ServiceBroker) error {
+	// TODO: Use the broker to obtain host service clients
+	return nil
 }
 
 // SetLogger is called by the framework when the plugin is loaded and provides

--- a/templates/server/notifier/notifier.go
+++ b/templates/server/notifier/notifier.go
@@ -83,13 +83,6 @@ func (p *Plugin) NotifyAndAdvise(ctx context.Context, req *notifierv1.NotifyAndA
 	return nil, status.Error(codes.Unimplemented, "not implemented")
 }
 
-// SetLogger is called by the framework when the plugin is loaded and provides
-// the plugin with a logger wired up to SPIRE's logging facilities.
-// TODO: Remove if the plugin does not need the logger.
-func (p *Plugin) SetLogger(logger hclog.Logger) {
-	p.logger = logger
-}
-
 // BrokerHostServices is called by the framework when the plugin is loaded to
 // give the plugin a chance to obtain clients to SPIRE host services.
 // TODO: Remove if the plugin does not need host services.
@@ -113,6 +106,13 @@ func (p *Plugin) Configure(ctx context.Context, req *configv1.ConfigureRequest) 
 
 	p.setConfig(config)
 	return &configv1.ConfigureResponse{}, nil
+}
+
+// SetLogger is called by the framework when the plugin is loaded and provides
+// the plugin with a logger wired up to SPIRE's logging facilities.
+// TODO: Remove if the plugin does not need the logger.
+func (p *Plugin) SetLogger(logger hclog.Logger) {
+	p.logger = logger
 }
 
 // setConfig replaces the configuration atomically under a write lock.

--- a/templates/server/notifier/notifier_test.go
+++ b/templates/server/notifier/notifier_test.go
@@ -1,6 +1,7 @@
 package notifier_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/spiffe/spire-plugin-sdk/pluginsdk"
@@ -8,11 +9,13 @@ import (
 	notifierv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/server/notifier/v1"
 	configv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/service/common/config/v1"
 	"github.com/spiffe/spire-plugin-sdk/templates/server/notifier"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test(t *testing.T) {
 	plugin := new(notifier.Plugin)
-	notClient := new(notifierv1.NotifierPluginClient)
+	ntClient := new(notifierv1.NotifierPluginClient)
 	configClient := new(configv1.ConfigServiceClient)
 
 	// Serve the plugin in the background with the configured plugin and
@@ -23,7 +26,7 @@ func Test(t *testing.T) {
 	// plugin.
 	plugintest.ServeInBackground(t, plugintest.Config{
 		PluginServer: notifierv1.NotifierPluginServer(plugin),
-		PluginClient: notClient,
+		PluginClient: ntClient,
 		ServiceServers: []pluginsdk.ServiceServer{
 			configv1.ConfigServiceServer(plugin),
 		},
@@ -32,5 +35,19 @@ func Test(t *testing.T) {
 		},
 	})
 
-	// TODO: Invoke methods on the clients and assert the results
+	ctx := context.Background()
+
+	// TODO: Remove if no configuration is required.
+	_, err := configClient.Configure(ctx, &configv1.ConfigureRequest{
+		CoreConfiguration: &configv1.CoreConfiguration{TrustDomain: "example.org"},
+		HclConfiguration:  `{}`,
+	})
+	assert.NoError(t, err)
+
+	require.True(t, ntClient.IsInitialized())
+	// TODO: Make assertions using the desired plugin behavior.
+	_, err = ntClient.Notify(ctx, &notifierv1.NotifyRequest{})
+	assert.EqualError(t, err, "rpc error: code = Unimplemented desc = not implemented")
+	_, err = ntClient.NotifyAndAdvise(ctx, &notifierv1.NotifyAndAdviseRequest{})
+	assert.EqualError(t, err, "rpc error: code = Unimplemented desc = not implemented")
 }

--- a/templates/server/upstreamauthority/upstreamauthority.go
+++ b/templates/server/upstreamauthority/upstreamauthority.go
@@ -15,12 +15,12 @@ import (
 )
 
 var (
-	// This compile time assertion ensures the plugin conforms properly to the
+	// This compile-time assertion ensures the plugin conforms properly to the
 	// pluginsdk.NeedsLogger interface.
 	// TODO: Remove if the plugin does not need the logger.
 	_ pluginsdk.NeedsLogger = (*Plugin)(nil)
 
-	// This compile time assertion ensures the plugin conforms properly to the
+	// This compile-time assertion ensures the plugin conforms properly to the
 	// pluginsdk.NeedsHostServices interface.
 	// TODO: Remove if the plugin does not need host services.
 	_ pluginsdk.NeedsHostServices = (*Plugin)(nil)
@@ -96,14 +96,6 @@ func (p *Plugin) PublishJWTKeyAndSubscribe(req *upstreamauthorityv1.PublishJWTKe
 	return status.Error(codes.Unimplemented, "not implemented")
 }
 
-// BrokerHostServices is called by the framework when the plugin is loaded to
-// give the plugin a chance to obtain clients to SPIRE host services.
-// TODO: Remove if the plugin does not need host services.
-func (p *Plugin) BrokerHostServices(broker pluginsdk.ServiceBroker) error {
-	// TODO: Use the broker to obtain host service clients
-	return nil
-}
-
 // Configure configures the plugin. This is invoked by SPIRE when the plugin is
 // first loaded. In the future, it may be invoked to reconfigure the plugin.
 // As such, it should replace the previous configuration atomically.
@@ -119,6 +111,14 @@ func (p *Plugin) Configure(ctx context.Context, req *configv1.ConfigureRequest) 
 
 	p.setConfig(config)
 	return &configv1.ConfigureResponse{}, nil
+}
+
+// BrokerHostServices is called by the framework when the plugin is loaded to
+// give the plugin a chance to obtain clients to SPIRE host services.
+// TODO: Remove if the plugin does not need host services.
+func (p *Plugin) BrokerHostServices(broker pluginsdk.ServiceBroker) error {
+	// TODO: Use the broker to obtain host service clients
+	return nil
 }
 
 // SetLogger is called by the framework when the plugin is loaded and provides

--- a/templates/server/upstreamauthority/upstreamauthority.go
+++ b/templates/server/upstreamauthority/upstreamauthority.go
@@ -94,7 +94,7 @@ func (p *Plugin) PublishJWTKeyAndSubscribe(req *upstreamauthorityv1.PublishJWTKe
 }
 
 // Configure configures the plugin. This is invoked by SPIRE when the plugin is
-// first loaded. In the future, tt may be invoked to reconfigure the plugin.
+// first loaded. In the future, it may be invoked to reconfigure the plugin.
 // As such, it should replace the previous configuration atomically.
 // TODO: Remove if no configuration is required
 func (p *Plugin) Configure(ctx context.Context, req *configv1.ConfigureRequest) (*configv1.ConfigureResponse, error) {

--- a/templates/server/upstreamauthority/upstreamauthority.go
+++ b/templates/server/upstreamauthority/upstreamauthority.go
@@ -96,13 +96,6 @@ func (p *Plugin) PublishJWTKeyAndSubscribe(req *upstreamauthorityv1.PublishJWTKe
 	return status.Error(codes.Unimplemented, "not implemented")
 }
 
-// SetLogger is called by the framework when the plugin is loaded and provides
-// the plugin with a logger wired up to SPIRE's logging facilities.
-// TODO: Remove if the plugin does not need the logger.
-func (p *Plugin) SetLogger(logger hclog.Logger) {
-	p.logger = logger
-}
-
 // BrokerHostServices is called by the framework when the plugin is loaded to
 // give the plugin a chance to obtain clients to SPIRE host services.
 // TODO: Remove if the plugin does not need host services.
@@ -126,6 +119,13 @@ func (p *Plugin) Configure(ctx context.Context, req *configv1.ConfigureRequest) 
 
 	p.setConfig(config)
 	return &configv1.ConfigureResponse{}, nil
+}
+
+// SetLogger is called by the framework when the plugin is loaded and provides
+// the plugin with a logger wired up to SPIRE's logging facilities.
+// TODO: Remove if the plugin does not need the logger.
+func (p *Plugin) SetLogger(logger hclog.Logger) {
+	p.logger = logger
 }
 
 // setConfig replaces the configuration atomically under a write lock.

--- a/templates/server/upstreamauthority/upstreamauthority.go
+++ b/templates/server/upstreamauthority/upstreamauthority.go
@@ -50,21 +50,14 @@ type Plugin struct {
 	logger hclog.Logger
 }
 
-// SetLogger is called by the framework when the plugin is loaded and provides
-// the plugin with a logger wired up to SPIRE's logging facilities.
-// TODO: Remove if the plugin does not need the logger.
-func (p *Plugin) SetLogger(logger hclog.Logger) {
-	p.logger = logger
-}
-
-// BrokerHostServices is called by the framework when the plugin is loaded to
-// give the plugin a chance to obtain clients to SPIRE host services.
-// TODO: Remove if the plugin does not need host services.
-func (p *Plugin) BrokerHostServices(broker pluginsdk.ServiceBroker) error {
-	// TODO: Use the broker to obtain host service clients
-	return nil
-}
-
+// MintX509CAAndSubscribe implements the UpstreamAuthority MintX509CAAndSubscribe RPC. Mints an X.509 CA and responds
+// with the signed X.509 CA certificate chain and upstream X.509 roots. If supported by the implementation, subsequent
+// responses on the stream contain upstream X.509 root updates, otherwise the stream is closed after the initial response.
+//
+// Implementation note:
+// The stream should be kept open in the face of transient errors
+// encountered while tracking changes to the upstream X.509 roots as SPIRE
+// Server will not reopen a closed stream until the next X.509 CA rotation.
 func (p *Plugin) MintX509CAAndSubscribe(req *upstreamauthorityv1.MintX509CARequest, stream upstreamauthorityv1.UpstreamAuthority_MintX509CAAndSubscribeServer) error {
 	config, err := p.getConfig()
 	if err != nil {
@@ -79,6 +72,16 @@ func (p *Plugin) MintX509CAAndSubscribe(req *upstreamauthorityv1.MintX509CAReque
 	return status.Error(codes.Unimplemented, "not implemented")
 }
 
+// PublishJWTKeyAndSubscribe implements the UpstreamAuthority PublishJWTKeyAndSubscribe RPC. Publishes a JWT signing key
+// upstream and responds with the upstream JWT keys. If supported by the implementation, subsequent responses on the
+// stream contain upstream JWT key updates, otherwise the stream is closed after the initial response.
+//
+// This RPC is optional and will return NotImplemented if unsupported.
+//
+// Implementation note:
+// The stream should be kept open in the face of transient errors
+// encountered while tracking changes to the upstream JWT keys as SPIRE
+// Server will not reopen a closed stream until the next JWT key rotation.
 func (p *Plugin) PublishJWTKeyAndSubscribe(req *upstreamauthorityv1.PublishJWTKeyRequest, stream upstreamauthorityv1.UpstreamAuthority_PublishJWTKeyAndSubscribeServer) error {
 	config, err := p.getConfig()
 	if err != nil {
@@ -91,6 +94,21 @@ func (p *Plugin) PublishJWTKeyAndSubscribe(req *upstreamauthorityv1.PublishJWTKe
 	config = config
 
 	return status.Error(codes.Unimplemented, "not implemented")
+}
+
+// SetLogger is called by the framework when the plugin is loaded and provides
+// the plugin with a logger wired up to SPIRE's logging facilities.
+// TODO: Remove if the plugin does not need the logger.
+func (p *Plugin) SetLogger(logger hclog.Logger) {
+	p.logger = logger
+}
+
+// BrokerHostServices is called by the framework when the plugin is loaded to
+// give the plugin a chance to obtain clients to SPIRE host services.
+// TODO: Remove if the plugin does not need host services.
+func (p *Plugin) BrokerHostServices(broker pluginsdk.ServiceBroker) error {
+	// TODO: Use the broker to obtain host service clients
+	return nil
 }
 
 // Configure configures the plugin. This is invoked by SPIRE when the plugin is

--- a/templates/server/upstreamauthority/upstreamauthority_test.go
+++ b/templates/server/upstreamauthority/upstreamauthority_test.go
@@ -35,7 +35,8 @@ func Test(t *testing.T) {
 		},
 	})
 
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	// TODO: Remove if no configuration is required.
 	_, err := configClient.Configure(ctx, &configv1.ConfigureRequest{
@@ -46,12 +47,12 @@ func Test(t *testing.T) {
 
 	require.True(t, uaClient.IsInitialized())
 	// TODO: Make assertions using the desired plugin behavior.
-	respMint, err := uaClient.MintX509CAAndSubscribe(ctx, &upstreamauthorityv1.MintX509CARequest{})
+	mintStream, err := uaClient.MintX509CAAndSubscribe(ctx, &upstreamauthorityv1.MintX509CARequest{})
 	require.NoError(t, err)
-	_, err = respMint.Recv()
+	_, err = mintStream.Recv()
 	assert.EqualError(t, err, "rpc error: code = Unimplemented desc = not implemented")
-	respPublish, err := uaClient.PublishJWTKeyAndSubscribe(ctx, &upstreamauthorityv1.PublishJWTKeyRequest{})
+	publishStream, err := uaClient.PublishJWTKeyAndSubscribe(ctx, &upstreamauthorityv1.PublishJWTKeyRequest{})
 	require.NoError(t, err)
-	_, err = respPublish.Recv()
+	_, err = publishStream.Recv()
 	assert.EqualError(t, err, "rpc error: code = Unimplemented desc = not implemented")
 }

--- a/templates/server/upstreamauthority/upstreamauthority_test.go
+++ b/templates/server/upstreamauthority/upstreamauthority_test.go
@@ -1,6 +1,7 @@
 package upstreamauthority_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/spiffe/spire-plugin-sdk/pluginsdk"
@@ -8,6 +9,8 @@ import (
 	upstreamauthorityv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/server/upstreamauthority/v1"
 	configv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/service/common/config/v1"
 	"github.com/spiffe/spire-plugin-sdk/templates/server/upstreamauthority"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test(t *testing.T) {
@@ -32,5 +35,23 @@ func Test(t *testing.T) {
 		},
 	})
 
-	// TODO: Invoke methods on the clients and assert the results
+	ctx := context.Background()
+
+	// TODO: Remove if no configuration is required.
+	_, err := configClient.Configure(ctx, &configv1.ConfigureRequest{
+		CoreConfiguration: &configv1.CoreConfiguration{TrustDomain: "example.org"},
+		HclConfiguration:  `{}`,
+	})
+	assert.NoError(t, err)
+
+	require.True(t, uaClient.IsInitialized())
+	// TODO: Make assertions using the desired plugin behavior.
+	respMint, err := uaClient.MintX509CAAndSubscribe(ctx, &upstreamauthorityv1.MintX509CARequest{})
+	require.NoError(t, err)
+	_, err = respMint.Recv()
+	assert.EqualError(t, err, "rpc error: code = Unimplemented desc = not implemented")
+	respPublish, err := uaClient.PublishJWTKeyAndSubscribe(ctx, &upstreamauthorityv1.PublishJWTKeyRequest{})
+	require.NoError(t, err)
+	_, err = respPublish.Recv()
+	assert.EqualError(t, err, "rpc error: code = Unimplemented desc = not implemented")
 }


### PR DESCRIPTION
### What has changed :thinking: 
This PR improves the authoring documentation with the following:
- Update AUTHORING.md file to include a link for the existing templates for each plugin type.
- Update templates to bring the actual plugin implementation closer to the plugin struct definition, including extra documentation on the implemented RPCs.
- Update template tests to include basic assertions on the implemented methods and in the plugin initialization.
- Fix some typos in general documentation

### Which issue does this PR fix :question: 
Fixes https://github.com/spiffe/spire-plugin-sdk/issues/46