### PR TITLE
Fix outdated mention of FetchAttestationData

### DIFF
--- a/proto/spire/plugin/agent/nodeattestor/v1/nodeattestor.proto
+++ b/proto/spire/plugin/agent/nodeattestor/v1/nodeattestor.proto
@@ -7,7 +7,7 @@ service NodeAttestor {
     // payload and participating in attestation challenge/response.
     //
     // The attestation flow is as follows:
-    // 1. SPIRE Agent opens up a stream to the plugin via FetchAttestationData.
+    // 1. SPIRE Agent opens up a stream to the plugin via AidAttestation.
     // 2. The plugin returns a response with the payload.
     // 3. SPIRE Agent sends the payload to SPIRE Server.
     // 4. Optionally, SPIRE Server responds with a challenge:


### PR DESCRIPTION
This function was replaced by AidAttestation and does not exist anymore.

The change was done in 01375380682ba2979e5fbb3de5bbea18f8658e93

Signed-off-by: Pavel Březina <pbrezina@redhat.com>
