### PR TITLE
Add new field to support yaml + hcl

### DIFF
--- a/proto/spire/service/common/config/v1/config.pb.go
+++ b/proto/spire/service/common/config/v1/config.pb.go
@@ -21,14 +21,68 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+type ConfigFormat int32
+
+const (
+	ConfigFormat_CONFIG_FORMAT_UNSPECIFIED ConfigFormat = 0
+	ConfigFormat_CONFIG_FORMAT_HCL         ConfigFormat = 1
+	ConfigFormat_CONFIG_FORMAT_YAML        ConfigFormat = 2
+)
+
+// Enum value maps for ConfigFormat.
+var (
+	ConfigFormat_name = map[int32]string{
+		0: "CONFIG_FORMAT_UNSPECIFIED",
+		1: "CONFIG_FORMAT_HCL",
+		2: "CONFIG_FORMAT_YAML",
+	}
+	ConfigFormat_value = map[string]int32{
+		"CONFIG_FORMAT_UNSPECIFIED": 0,
+		"CONFIG_FORMAT_HCL":         1,
+		"CONFIG_FORMAT_YAML":        2,
+	}
+)
+
+func (x ConfigFormat) Enum() *ConfigFormat {
+	p := new(ConfigFormat)
+	*p = x
+	return p
+}
+
+func (x ConfigFormat) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (ConfigFormat) Descriptor() protoreflect.EnumDescriptor {
+	return file_spire_service_common_config_v1_config_proto_enumTypes[0].Descriptor()
+}
+
+func (ConfigFormat) Type() protoreflect.EnumType {
+	return &file_spire_service_common_config_v1_config_proto_enumTypes[0]
+}
+
+func (x ConfigFormat) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use ConfigFormat.Descriptor instead.
+func (ConfigFormat) EnumDescriptor() ([]byte, []int) {
+	return file_spire_service_common_config_v1_config_proto_rawDescGZIP(), []int{0}
+}
+
 type ConfigureRequest struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	// Required. Core SPIRE configuration.
-	CoreConfiguration *CoreConfiguration `protobuf:"bytes,1,opt,name=core_configuration,json=coreConfiguration,proto3" json:"core_configuration,omitempty"`
-	// Required. HCL encoded plugin configuration.
+	state             protoimpl.MessageState `protogen:"open.v1"`
+	CoreConfiguration *CoreConfiguration     `protobuf:"bytes,1,opt,name=core_configuration,json=coreConfiguration,proto3" json:"core_configuration,omitempty"`
+	// Deprecated: use configuration with config_format. Kept for backward compat with old plugins.
+	//
+	// Deprecated: Marked as deprecated in spire/service/common/config/v1/config.proto.
 	HclConfiguration string `protobuf:"bytes,2,opt,name=hcl_configuration,json=hclConfiguration,proto3" json:"hcl_configuration,omitempty"`
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
+	// Raw plugin configuration string in the format specified by configFormat.
+	// When set, takes precedence over hclConfiguration.
+	Configuration string       `protobuf:"bytes,3,opt,name=configuration,proto3" json:"configuration,omitempty"`
+	ConfigFormat  ConfigFormat `protobuf:"varint,4,opt,name=config_format,json=configFormat,proto3,enum=spire.service.common.config.v1.ConfigFormat" json:"config_format,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ConfigureRequest) Reset() {
@@ -68,11 +122,26 @@ func (x *ConfigureRequest) GetCoreConfiguration() *CoreConfiguration {
 	return nil
 }
 
+// Deprecated: Marked as deprecated in spire/service/common/config/v1/config.proto.
 func (x *ConfigureRequest) GetHclConfiguration() string {
 	if x != nil {
 		return x.HclConfiguration
 	}
 	return ""
+}
+
+func (x *ConfigureRequest) GetConfiguration() string {
+	if x != nil {
+		return x.Configuration
+	}
+	return ""
+}
+
+func (x *ConfigureRequest) GetConfigFormat() ConfigFormat {
+	if x != nil {
+		return x.ConfigFormat
+	}
+	return ConfigFormat_CONFIG_FORMAT_UNSPECIFIED
 }
 
 type ConfigureResponse struct {
@@ -112,13 +181,18 @@ func (*ConfigureResponse) Descriptor() ([]byte, []int) {
 }
 
 type ValidateRequest struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	// Required. Core SPIRE configuration.
-	CoreConfiguration *CoreConfiguration `protobuf:"bytes,1,opt,name=core_configuration,json=coreConfiguration,proto3" json:"core_configuration,omitempty"`
-	// Required. HCL encoded plugin configuration.
+	state             protoimpl.MessageState `protogen:"open.v1"`
+	CoreConfiguration *CoreConfiguration     `protobuf:"bytes,1,opt,name=core_configuration,json=coreConfiguration,proto3" json:"core_configuration,omitempty"`
+	// Deprecated: use configuration with config_format. Kept for backward compat with old plugins.
+	//
+	// Deprecated: Marked as deprecated in spire/service/common/config/v1/config.proto.
 	HclConfiguration string `protobuf:"bytes,2,opt,name=hcl_configuration,json=hclConfiguration,proto3" json:"hcl_configuration,omitempty"`
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
+	// Raw plugin configuration string in the format specified by configFormat.
+	// When set, takes precedence over hclConfiguration.
+	Configuration string       `protobuf:"bytes,3,opt,name=configuration,proto3" json:"configuration,omitempty"`
+	ConfigFormat  ConfigFormat `protobuf:"varint,4,opt,name=config_format,json=configFormat,proto3,enum=spire.service.common.config.v1.ConfigFormat" json:"config_format,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ValidateRequest) Reset() {
@@ -158,11 +232,26 @@ func (x *ValidateRequest) GetCoreConfiguration() *CoreConfiguration {
 	return nil
 }
 
+// Deprecated: Marked as deprecated in spire/service/common/config/v1/config.proto.
 func (x *ValidateRequest) GetHclConfiguration() string {
 	if x != nil {
 		return x.HclConfiguration
 	}
 	return ""
+}
+
+func (x *ValidateRequest) GetConfiguration() string {
+	if x != nil {
+		return x.Configuration
+	}
+	return ""
+}
+
+func (x *ValidateRequest) GetConfigFormat() ConfigFormat {
+	if x != nil {
+		return x.ConfigFormat
+	}
+	return ConfigFormat_CONFIG_FORMAT_UNSPECIFIED
 }
 
 type ValidateResponse struct {
@@ -273,19 +362,27 @@ var File_spire_service_common_config_v1_config_proto protoreflect.FileDescriptor
 
 const file_spire_service_common_config_v1_config_proto_rawDesc = "" +
 	"\n" +
-	"+spire/service/common/config/v1/config.proto\x12\x1espire.service.common.config.v1\"\xa1\x01\n" +
+	"+spire/service/common/config/v1/config.proto\x12\x1espire.service.common.config.v1\"\x9e\x02\n" +
 	"\x10ConfigureRequest\x12`\n" +
-	"\x12core_configuration\x18\x01 \x01(\v21.spire.service.common.config.v1.CoreConfigurationR\x11coreConfiguration\x12+\n" +
-	"\x11hcl_configuration\x18\x02 \x01(\tR\x10hclConfiguration\"\x13\n" +
-	"\x11ConfigureResponse\"\xa0\x01\n" +
+	"\x12core_configuration\x18\x01 \x01(\v21.spire.service.common.config.v1.CoreConfigurationR\x11coreConfiguration\x12/\n" +
+	"\x11hcl_configuration\x18\x02 \x01(\tB\x02\x18\x01R\x10hclConfiguration\x12$\n" +
+	"\rconfiguration\x18\x03 \x01(\tR\rconfiguration\x12Q\n" +
+	"\rconfig_format\x18\x04 \x01(\x0e2,.spire.service.common.config.v1.ConfigFormatR\fconfigFormat\"\x13\n" +
+	"\x11ConfigureResponse\"\x9d\x02\n" +
 	"\x0fValidateRequest\x12`\n" +
-	"\x12core_configuration\x18\x01 \x01(\v21.spire.service.common.config.v1.CoreConfigurationR\x11coreConfiguration\x12+\n" +
-	"\x11hcl_configuration\x18\x02 \x01(\tR\x10hclConfiguration\">\n" +
+	"\x12core_configuration\x18\x01 \x01(\v21.spire.service.common.config.v1.CoreConfigurationR\x11coreConfiguration\x12/\n" +
+	"\x11hcl_configuration\x18\x02 \x01(\tB\x02\x18\x01R\x10hclConfiguration\x12$\n" +
+	"\rconfiguration\x18\x03 \x01(\tR\rconfiguration\x12Q\n" +
+	"\rconfig_format\x18\x04 \x01(\x0e2,.spire.service.common.config.v1.ConfigFormatR\fconfigFormat\">\n" +
 	"\x10ValidateResponse\x12\x14\n" +
 	"\x05valid\x18\x01 \x01(\bR\x05valid\x12\x14\n" +
 	"\x05notes\x18\x02 \x03(\tR\x05notes\"6\n" +
 	"\x11CoreConfiguration\x12!\n" +
-	"\ftrust_domain\x18\x01 \x01(\tR\vtrustDomain2\xe9\x01\n" +
+	"\ftrust_domain\x18\x01 \x01(\tR\vtrustDomain*\\\n" +
+	"\fConfigFormat\x12\x1d\n" +
+	"\x19CONFIG_FORMAT_UNSPECIFIED\x10\x00\x12\x15\n" +
+	"\x11CONFIG_FORMAT_HCL\x10\x01\x12\x16\n" +
+	"\x12CONFIG_FORMAT_YAML\x10\x022\xe9\x01\n" +
 	"\x06Config\x12p\n" +
 	"\tConfigure\x120.spire.service.common.config.v1.ConfigureRequest\x1a1.spire.service.common.config.v1.ConfigureResponse\x12m\n" +
 	"\bValidate\x12/.spire.service.common.config.v1.ValidateRequest\x1a0.spire.service.common.config.v1.ValidateResponseBRZPgithub.com/spiffe/spire-plugin-sdk/proto/spire/service/common/config/v1;configv1b\x06proto3"
@@ -302,26 +399,30 @@ func file_spire_service_common_config_v1_config_proto_rawDescGZIP() []byte {
 	return file_spire_service_common_config_v1_config_proto_rawDescData
 }
 
+var file_spire_service_common_config_v1_config_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
 var file_spire_service_common_config_v1_config_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
 var file_spire_service_common_config_v1_config_proto_goTypes = []any{
-	(*ConfigureRequest)(nil),  // 0: spire.service.common.config.v1.ConfigureRequest
-	(*ConfigureResponse)(nil), // 1: spire.service.common.config.v1.ConfigureResponse
-	(*ValidateRequest)(nil),   // 2: spire.service.common.config.v1.ValidateRequest
-	(*ValidateResponse)(nil),  // 3: spire.service.common.config.v1.ValidateResponse
-	(*CoreConfiguration)(nil), // 4: spire.service.common.config.v1.CoreConfiguration
+	(ConfigFormat)(0),         // 0: spire.service.common.config.v1.ConfigFormat
+	(*ConfigureRequest)(nil),  // 1: spire.service.common.config.v1.ConfigureRequest
+	(*ConfigureResponse)(nil), // 2: spire.service.common.config.v1.ConfigureResponse
+	(*ValidateRequest)(nil),   // 3: spire.service.common.config.v1.ValidateRequest
+	(*ValidateResponse)(nil),  // 4: spire.service.common.config.v1.ValidateResponse
+	(*CoreConfiguration)(nil), // 5: spire.service.common.config.v1.CoreConfiguration
 }
 var file_spire_service_common_config_v1_config_proto_depIdxs = []int32{
-	4, // 0: spire.service.common.config.v1.ConfigureRequest.core_configuration:type_name -> spire.service.common.config.v1.CoreConfiguration
-	4, // 1: spire.service.common.config.v1.ValidateRequest.core_configuration:type_name -> spire.service.common.config.v1.CoreConfiguration
-	0, // 2: spire.service.common.config.v1.Config.Configure:input_type -> spire.service.common.config.v1.ConfigureRequest
-	2, // 3: spire.service.common.config.v1.Config.Validate:input_type -> spire.service.common.config.v1.ValidateRequest
-	1, // 4: spire.service.common.config.v1.Config.Configure:output_type -> spire.service.common.config.v1.ConfigureResponse
-	3, // 5: spire.service.common.config.v1.Config.Validate:output_type -> spire.service.common.config.v1.ValidateResponse
-	4, // [4:6] is the sub-list for method output_type
-	2, // [2:4] is the sub-list for method input_type
-	2, // [2:2] is the sub-list for extension type_name
-	2, // [2:2] is the sub-list for extension extendee
-	0, // [0:2] is the sub-list for field type_name
+	5, // 0: spire.service.common.config.v1.ConfigureRequest.core_configuration:type_name -> spire.service.common.config.v1.CoreConfiguration
+	0, // 1: spire.service.common.config.v1.ConfigureRequest.config_format:type_name -> spire.service.common.config.v1.ConfigFormat
+	5, // 2: spire.service.common.config.v1.ValidateRequest.core_configuration:type_name -> spire.service.common.config.v1.CoreConfiguration
+	0, // 3: spire.service.common.config.v1.ValidateRequest.config_format:type_name -> spire.service.common.config.v1.ConfigFormat
+	1, // 4: spire.service.common.config.v1.Config.Configure:input_type -> spire.service.common.config.v1.ConfigureRequest
+	3, // 5: spire.service.common.config.v1.Config.Validate:input_type -> spire.service.common.config.v1.ValidateRequest
+	2, // 6: spire.service.common.config.v1.Config.Configure:output_type -> spire.service.common.config.v1.ConfigureResponse
+	4, // 7: spire.service.common.config.v1.Config.Validate:output_type -> spire.service.common.config.v1.ValidateResponse
+	6, // [6:8] is the sub-list for method output_type
+	4, // [4:6] is the sub-list for method input_type
+	4, // [4:4] is the sub-list for extension type_name
+	4, // [4:4] is the sub-list for extension extendee
+	0, // [0:4] is the sub-list for field type_name
 }
 
 func init() { file_spire_service_common_config_v1_config_proto_init() }
@@ -334,13 +435,14 @@ func file_spire_service_common_config_v1_config_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_spire_service_common_config_v1_config_proto_rawDesc), len(file_spire_service_common_config_v1_config_proto_rawDesc)),
-			NumEnums:      0,
+			NumEnums:      1,
 			NumMessages:   5,
 			NumExtensions: 0,
 			NumServices:   1,
 		},
 		GoTypes:           file_spire_service_common_config_v1_config_proto_goTypes,
 		DependencyIndexes: file_spire_service_common_config_v1_config_proto_depIdxs,
+		EnumInfos:         file_spire_service_common_config_v1_config_proto_enumTypes,
 		MessageInfos:      file_spire_service_common_config_v1_config_proto_msgTypes,
 	}.Build()
 	File_spire_service_common_config_v1_config_proto = out.File

--- a/proto/spire/service/common/config/v1/config.proto
+++ b/proto/spire/service/common/config/v1/config.proto
@@ -18,23 +18,33 @@ service Config {
     rpc Validate(ValidateRequest) returns (ValidateResponse);
 }
 
-message ConfigureRequest {
-    // Required. Core SPIRE configuration.
-    CoreConfiguration core_configuration = 1;
+enum ConfigFormat {
+    CONFIG_FORMAT_UNSPECIFIED = 0;
+    CONFIG_FORMAT_HCL = 1;
+    CONFIG_FORMAT_YAML = 2;
+}
 
-    // Required. HCL encoded plugin configuration.
-    string hcl_configuration = 2;
+message ConfigureRequest {
+    CoreConfiguration core_configuration = 1;
+    // Deprecated: use configuration with config_format. Kept for backward compat with old plugins.
+    string hcl_configuration = 2 [deprecated = true];
+    // Raw plugin configuration string in the format specified by configFormat.
+    // When set, takes precedence over hclConfiguration.
+    string configuration = 3;
+    ConfigFormat config_format = 4;
 }
 
 message ConfigureResponse {
 }
 
 message ValidateRequest {
-    // Required. Core SPIRE configuration.
     CoreConfiguration core_configuration = 1;
-
-    // Required. HCL encoded plugin configuration.
-    string hcl_configuration = 2;
+    // Deprecated: use configuration with config_format. Kept for backward compat with old plugins.
+    string hcl_configuration = 2 [deprecated = true];
+    // Raw plugin configuration string in the format specified by configFormat.
+    // When set, takes precedence over hclConfiguration.
+    string configuration = 3;
+    ConfigFormat config_format = 4;
 }
 
 message ValidateResponse {


### PR DESCRIPTION
It is an initial idea to allow configure yaml or hcl on plugins, 
we may be able to make the same with hclConfiguration + format but I tried to no add more than expected on the existing filed.
Anohter option is to remove the type and in hcl we receive hcl and in the configuration yaml... open to optinions here