### PR TITLE
Revert "Introduce AttestReference API in workloadattestor (#74)"

### DIFF
--- a/proto/spire/plugin/agent/workloadattestor/v1/workloadattestor.pb.go
+++ b/proto/spire/plugin/agent/workloadattestor/v1/workloadattestor.pb.go
@@ -9,7 +9,6 @@ package v1
 import (
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
-	anypb "google.golang.org/protobuf/types/known/anypb"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
@@ -113,116 +112,17 @@ func (x *AttestResponse) GetSelectorValues() []string {
 	return nil
 }
 
-type AttestReferenceRequest struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	// Required. Reference to the workload to be attested. The packed message
-	// is one of the WorkloadReference reference types defined by the SPIFFE
-	// Broker API specification (e.g. WorkloadPIDReference,
-	// KubernetesObjectReference) or a vendor-specific extension type.
-	Reference     *anypb.Any `protobuf:"bytes,1,opt,name=reference,proto3" json:"reference,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *AttestReferenceRequest) Reset() {
-	*x = AttestReferenceRequest{}
-	mi := &file_spire_plugin_agent_workloadattestor_v1_workloadattestor_proto_msgTypes[2]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *AttestReferenceRequest) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*AttestReferenceRequest) ProtoMessage() {}
-
-func (x *AttestReferenceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_spire_plugin_agent_workloadattestor_v1_workloadattestor_proto_msgTypes[2]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use AttestReferenceRequest.ProtoReflect.Descriptor instead.
-func (*AttestReferenceRequest) Descriptor() ([]byte, []int) {
-	return file_spire_plugin_agent_workloadattestor_v1_workloadattestor_proto_rawDescGZIP(), []int{2}
-}
-
-func (x *AttestReferenceRequest) GetReference() *anypb.Any {
-	if x != nil {
-		return x.Reference
-	}
-	return nil
-}
-
-type AttestReferenceResponse struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	// Optional. Selector values related to the attested workload. The type
-	// of the selector is inferred from the plugin name.
-	SelectorValues []string `protobuf:"bytes,1,rep,name=selector_values,json=selectorValues,proto3" json:"selector_values,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
-}
-
-func (x *AttestReferenceResponse) Reset() {
-	*x = AttestReferenceResponse{}
-	mi := &file_spire_plugin_agent_workloadattestor_v1_workloadattestor_proto_msgTypes[3]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *AttestReferenceResponse) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*AttestReferenceResponse) ProtoMessage() {}
-
-func (x *AttestReferenceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_spire_plugin_agent_workloadattestor_v1_workloadattestor_proto_msgTypes[3]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use AttestReferenceResponse.ProtoReflect.Descriptor instead.
-func (*AttestReferenceResponse) Descriptor() ([]byte, []int) {
-	return file_spire_plugin_agent_workloadattestor_v1_workloadattestor_proto_rawDescGZIP(), []int{3}
-}
-
-func (x *AttestReferenceResponse) GetSelectorValues() []string {
-	if x != nil {
-		return x.SelectorValues
-	}
-	return nil
-}
-
 var File_spire_plugin_agent_workloadattestor_v1_workloadattestor_proto protoreflect.FileDescriptor
 
 const file_spire_plugin_agent_workloadattestor_v1_workloadattestor_proto_rawDesc = "" +
 	"\n" +
-	"=spire/plugin/agent/workloadattestor/v1/workloadattestor.proto\x12&spire.plugin.agent.workloadattestor.v1\x1a\x19google/protobuf/any.proto\"!\n" +
+	"=spire/plugin/agent/workloadattestor/v1/workloadattestor.proto\x12&spire.plugin.agent.workloadattestor.v1\"!\n" +
 	"\rAttestRequest\x12\x10\n" +
 	"\x03pid\x18\x01 \x01(\x05R\x03pid\"9\n" +
 	"\x0eAttestResponse\x12'\n" +
-	"\x0fselector_values\x18\x01 \x03(\tR\x0eselectorValues\"L\n" +
-	"\x16AttestReferenceRequest\x122\n" +
-	"\treference\x18\x01 \x01(\v2\x14.google.protobuf.AnyR\treference\"B\n" +
-	"\x17AttestReferenceResponse\x12'\n" +
-	"\x0fselector_values\x18\x01 \x03(\tR\x0eselectorValues2\xa0\x02\n" +
+	"\x0fselector_values\x18\x01 \x03(\tR\x0eselectorValues2\x8b\x01\n" +
 	"\x10WorkloadAttestor\x12w\n" +
-	"\x06Attest\x125.spire.plugin.agent.workloadattestor.v1.AttestRequest\x1a6.spire.plugin.agent.workloadattestor.v1.AttestResponse\x12\x92\x01\n" +
-	"\x0fAttestReference\x12>.spire.plugin.agent.workloadattestor.v1.AttestReferenceRequest\x1a?.spire.plugin.agent.workloadattestor.v1.AttestReferenceResponseBQZOgithub.com/spiffe/spire-plugin-sdk/proto/spire/plugin/agent/workloadattestor/v1b\x06proto3"
+	"\x06Attest\x125.spire.plugin.agent.workloadattestor.v1.AttestRequest\x1a6.spire.plugin.agent.workloadattestor.v1.AttestResponseBQZOgithub.com/spiffe/spire-plugin-sdk/proto/spire/plugin/agent/workloadattestor/v1b\x06proto3"
 
 var (
 	file_spire_plugin_agent_workloadattestor_v1_workloadattestor_proto_rawDescOnce sync.Once
@@ -236,25 +136,19 @@ func file_spire_plugin_agent_workloadattestor_v1_workloadattestor_proto_rawDescG
 	return file_spire_plugin_agent_workloadattestor_v1_workloadattestor_proto_rawDescData
 }
 
-var file_spire_plugin_agent_workloadattestor_v1_workloadattestor_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
+var file_spire_plugin_agent_workloadattestor_v1_workloadattestor_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
 var file_spire_plugin_agent_workloadattestor_v1_workloadattestor_proto_goTypes = []any{
-	(*AttestRequest)(nil),           // 0: spire.plugin.agent.workloadattestor.v1.AttestRequest
-	(*AttestResponse)(nil),          // 1: spire.plugin.agent.workloadattestor.v1.AttestResponse
-	(*AttestReferenceRequest)(nil),  // 2: spire.plugin.agent.workloadattestor.v1.AttestReferenceRequest
-	(*AttestReferenceResponse)(nil), // 3: spire.plugin.agent.workloadattestor.v1.AttestReferenceResponse
-	(*anypb.Any)(nil),               // 4: google.protobuf.Any
+	(*AttestRequest)(nil),  // 0: spire.plugin.agent.workloadattestor.v1.AttestRequest
+	(*AttestResponse)(nil), // 1: spire.plugin.agent.workloadattestor.v1.AttestResponse
 }
 var file_spire_plugin_agent_workloadattestor_v1_workloadattestor_proto_depIdxs = []int32{
-	4, // 0: spire.plugin.agent.workloadattestor.v1.AttestReferenceRequest.reference:type_name -> google.protobuf.Any
-	0, // 1: spire.plugin.agent.workloadattestor.v1.WorkloadAttestor.Attest:input_type -> spire.plugin.agent.workloadattestor.v1.AttestRequest
-	2, // 2: spire.plugin.agent.workloadattestor.v1.WorkloadAttestor.AttestReference:input_type -> spire.plugin.agent.workloadattestor.v1.AttestReferenceRequest
-	1, // 3: spire.plugin.agent.workloadattestor.v1.WorkloadAttestor.Attest:output_type -> spire.plugin.agent.workloadattestor.v1.AttestResponse
-	3, // 4: spire.plugin.agent.workloadattestor.v1.WorkloadAttestor.AttestReference:output_type -> spire.plugin.agent.workloadattestor.v1.AttestReferenceResponse
-	3, // [3:5] is the sub-list for method output_type
-	1, // [1:3] is the sub-list for method input_type
-	1, // [1:1] is the sub-list for extension type_name
-	1, // [1:1] is the sub-list for extension extendee
-	0, // [0:1] is the sub-list for field type_name
+	0, // 0: spire.plugin.agent.workloadattestor.v1.WorkloadAttestor.Attest:input_type -> spire.plugin.agent.workloadattestor.v1.AttestRequest
+	1, // 1: spire.plugin.agent.workloadattestor.v1.WorkloadAttestor.Attest:output_type -> spire.plugin.agent.workloadattestor.v1.AttestResponse
+	1, // [1:2] is the sub-list for method output_type
+	0, // [0:1] is the sub-list for method input_type
+	0, // [0:0] is the sub-list for extension type_name
+	0, // [0:0] is the sub-list for extension extendee
+	0, // [0:0] is the sub-list for field type_name
 }
 
 func init() { file_spire_plugin_agent_workloadattestor_v1_workloadattestor_proto_init() }
@@ -268,7 +162,7 @@ func file_spire_plugin_agent_workloadattestor_v1_workloadattestor_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_spire_plugin_agent_workloadattestor_v1_workloadattestor_proto_rawDesc), len(file_spire_plugin_agent_workloadattestor_v1_workloadattestor_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   4,
+			NumMessages:   2,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/proto/spire/plugin/agent/workloadattestor/v1/workloadattestor.proto
+++ b/proto/spire/plugin/agent/workloadattestor/v1/workloadattestor.proto
@@ -2,8 +2,6 @@ syntax = "proto3";
 package spire.plugin.agent.workloadattestor.v1;
 option go_package = "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/agent/workloadattestor/v1";
 
-import "google/protobuf/any.proto";
-
 service WorkloadAttestor {
     // Attests the specified workload process. If the process is not one the
     // attestor is in a position to attest (e.g. k8s attestor attesting a
@@ -12,16 +10,6 @@ service WorkloadAttestor {
     // fails to gather all selectors related to that workload, the call will
     // fail. Otherwise the attestor will return one or more workload selectors.
     rpc Attest(AttestRequest) returns (AttestResponse);
-
-    // Attests a workload identified by an opaque reference (e.g. a process
-    // ID, a Kubernetes object reference, etc.). The reference's type URL is
-    // taken from the SPIFFE Broker API specification's WorkloadReference and
-    // delivered verbatim. A plugin that does not implement reference-based
-    // attestation at all returns Unimplemented, which lets the host fall back
-    // to Attest when the reference is a WorkloadPIDReference. A plugin that
-    // implements this RPC but receives a reference type it does not support
-    // returns InvalidArgument.
-    rpc AttestReference(AttestReferenceRequest) returns (AttestReferenceResponse);
 }
 
 message AttestRequest {
@@ -30,20 +18,6 @@ message AttestRequest {
 }
 
 message AttestResponse {
-    // Optional. Selector values related to the attested workload. The type
-    // of the selector is inferred from the plugin name.
-    repeated string selector_values = 1;
-}
-
-message AttestReferenceRequest {
-    // Required. Reference to the workload to be attested. The packed message
-    // is one of the WorkloadReference reference types defined by the SPIFFE
-    // Broker API specification (e.g. WorkloadPIDReference,
-    // KubernetesObjectReference) or a vendor-specific extension type.
-    google.protobuf.Any reference = 1;
-}
-
-message AttestReferenceResponse {
     // Optional. Selector values related to the attested workload. The type
     // of the selector is inferred from the plugin name.
     repeated string selector_values = 1;

--- a/proto/spire/plugin/agent/workloadattestor/v1/workloadattestor_grpc.pb.go
+++ b/proto/spire/plugin/agent/workloadattestor/v1/workloadattestor_grpc.pb.go
@@ -19,8 +19,7 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	WorkloadAttestor_Attest_FullMethodName          = "/spire.plugin.agent.workloadattestor.v1.WorkloadAttestor/Attest"
-	WorkloadAttestor_AttestReference_FullMethodName = "/spire.plugin.agent.workloadattestor.v1.WorkloadAttestor/AttestReference"
+	WorkloadAttestor_Attest_FullMethodName = "/spire.plugin.agent.workloadattestor.v1.WorkloadAttestor/Attest"
 )
 
 // WorkloadAttestorClient is the client API for WorkloadAttestor service.
@@ -34,15 +33,6 @@ type WorkloadAttestorClient interface {
 	// fails to gather all selectors related to that workload, the call will
 	// fail. Otherwise the attestor will return one or more workload selectors.
 	Attest(ctx context.Context, in *AttestRequest, opts ...grpc.CallOption) (*AttestResponse, error)
-	// Attests a workload identified by an opaque reference (e.g. a process
-	// ID, a Kubernetes object reference, etc.). The reference's type URL is
-	// taken from the SPIFFE Broker API specification's WorkloadReference and
-	// delivered verbatim. A plugin that does not implement reference-based
-	// attestation at all returns Unimplemented, which lets the host fall back
-	// to Attest when the reference is a WorkloadPIDReference. A plugin that
-	// implements this RPC but receives a reference type it does not support
-	// returns InvalidArgument.
-	AttestReference(ctx context.Context, in *AttestReferenceRequest, opts ...grpc.CallOption) (*AttestReferenceResponse, error)
 }
 
 type workloadAttestorClient struct {
@@ -63,16 +53,6 @@ func (c *workloadAttestorClient) Attest(ctx context.Context, in *AttestRequest, 
 	return out, nil
 }
 
-func (c *workloadAttestorClient) AttestReference(ctx context.Context, in *AttestReferenceRequest, opts ...grpc.CallOption) (*AttestReferenceResponse, error) {
-	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	out := new(AttestReferenceResponse)
-	err := c.cc.Invoke(ctx, WorkloadAttestor_AttestReference_FullMethodName, in, out, cOpts...)
-	if err != nil {
-		return nil, err
-	}
-	return out, nil
-}
-
 // WorkloadAttestorServer is the server API for WorkloadAttestor service.
 // All implementations must embed UnimplementedWorkloadAttestorServer
 // for forward compatibility.
@@ -84,15 +64,6 @@ type WorkloadAttestorServer interface {
 	// fails to gather all selectors related to that workload, the call will
 	// fail. Otherwise the attestor will return one or more workload selectors.
 	Attest(context.Context, *AttestRequest) (*AttestResponse, error)
-	// Attests a workload identified by an opaque reference (e.g. a process
-	// ID, a Kubernetes object reference, etc.). The reference's type URL is
-	// taken from the SPIFFE Broker API specification's WorkloadReference and
-	// delivered verbatim. A plugin that does not implement reference-based
-	// attestation at all returns Unimplemented, which lets the host fall back
-	// to Attest when the reference is a WorkloadPIDReference. A plugin that
-	// implements this RPC but receives a reference type it does not support
-	// returns InvalidArgument.
-	AttestReference(context.Context, *AttestReferenceRequest) (*AttestReferenceResponse, error)
 	mustEmbedUnimplementedWorkloadAttestorServer()
 }
 
@@ -105,9 +76,6 @@ type UnimplementedWorkloadAttestorServer struct{}
 
 func (UnimplementedWorkloadAttestorServer) Attest(context.Context, *AttestRequest) (*AttestResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Attest not implemented")
-}
-func (UnimplementedWorkloadAttestorServer) AttestReference(context.Context, *AttestReferenceRequest) (*AttestReferenceResponse, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method AttestReference not implemented")
 }
 func (UnimplementedWorkloadAttestorServer) mustEmbedUnimplementedWorkloadAttestorServer() {}
 func (UnimplementedWorkloadAttestorServer) testEmbeddedByValue()                          {}
@@ -148,24 +116,6 @@ func _WorkloadAttestor_Attest_Handler(srv interface{}, ctx context.Context, dec 
 	return interceptor(ctx, in, info, handler)
 }
 
-func _WorkloadAttestor_AttestReference_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(AttestReferenceRequest)
-	if err := dec(in); err != nil {
-		return nil, err
-	}
-	if interceptor == nil {
-		return srv.(WorkloadAttestorServer).AttestReference(ctx, in)
-	}
-	info := &grpc.UnaryServerInfo{
-		Server:     srv,
-		FullMethod: WorkloadAttestor_AttestReference_FullMethodName,
-	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(WorkloadAttestorServer).AttestReference(ctx, req.(*AttestReferenceRequest))
-	}
-	return interceptor(ctx, in, info, handler)
-}
-
 // WorkloadAttestor_ServiceDesc is the grpc.ServiceDesc for WorkloadAttestor service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -176,10 +126,6 @@ var WorkloadAttestor_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "Attest",
 			Handler:    _WorkloadAttestor_Attest_Handler,
-		},
-		{
-			MethodName: "AttestReference",
-			Handler:    _WorkloadAttestor_AttestReference_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/templates/agent/workloadattestor/workloadattestor.go
+++ b/templates/agent/workloadattestor/workloadattestor.go
@@ -69,25 +69,6 @@ func (p *Plugin) Attest(ctx context.Context, req *workloadattestorv1.AttestReque
 	return nil, status.Error(codes.Unimplemented, "not implemented")
 }
 
-// AttestReference implements the WorkloadAttestor AttestReference RPC. Attests a workload identified by an opaque
-// reference (e.g. a process ID, a Kubernetes object reference, etc.). A plugin that does not implement
-// reference-based attestation at all returns Unimplemented, which lets the host fall back to Attest when the
-// reference is a WorkloadPIDReference. A plugin that implements this RPC but receives a reference type it does not
-// support returns InvalidArgument.
-func (p *Plugin) AttestReference(ctx context.Context, req *workloadattestorv1.AttestReferenceRequest) (*workloadattestorv1.AttestReferenceResponse, error) {
-	config, err := p.getConfig()
-	if err != nil {
-		return nil, err
-	}
-
-	// TODO: Implement the RPC behavior. The following line silences compiler
-	// warnings and can be removed once the configuration is referenced by the
-	// implementation.
-	config = config
-
-	return nil, status.Error(codes.Unimplemented, "not implemented")
-}
-
 // Configure configures the plugin. This is invoked by SPIRE when the plugin is
 // first loaded. In the future, it may be invoked to reconfigure the plugin.
 // As such, it should replace the previous configuration atomically.


### PR DESCRIPTION
PR #74 was merged directly into main, but main should only receive changes cherry-picked from next ahead of a SPIRE release.

This reverts the change on main. It has been cherry-picked onto next in #78, which is the correct staging branch and the one SPIRE's main consumes via the @next pseudo-version. The change will return to main through the normal release-time cherry-pick once it is ready.