### PR TITLE
Update CODEOWNERS to reflect current SPIRE maintainers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @evan2645 @amartinezfayo @sorindumitru @MarcosDY @rturner3
+* @amartinezfayo @MarcosDY @rturner3 @sorindumitru


### PR DESCRIPTION
Update CODEOWNERS to reflect the current set of SPIRE maintainers, removing maintainers who are no longer active on the project and aligning the owners across the main and next branches.