### PR TITLE
Update CODEOWNERS to use spire-maintainers team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @amartinezfayo @MarcosDY @rturner3 @sorindumitru
+* @spiffe/spire-maintainers


### PR DESCRIPTION
Replaces the hard-coded list of individual maintainers in `CODEOWNERS` with the `@spiffe/spire-maintainers` team.

Pointing at the team means ownership tracks team membership automatically, so maintainers joining or leaving no longer requires a separate change to this file and we can more trivially synchronsie this list between multiple repositories.
